### PR TITLE
added lookup when even expanded_url is a shortened url

### DIFF
--- a/utils/urls.py
+++ b/utils/urls.py
@@ -3,11 +3,22 @@
 import json
 import fileinput
 import dateutil.parser
+import requests
+
+shorteners = "http://bit.ly/", "http://goo.gl/", "http://t.co/", "http://tinyurl.com/", "http://is.gd/", "http://wp.me/", "http://fb.me/", "http://ow.ly/"
 
 for line in fileinput.input():
     tweet = json.loads(line)
     for url in tweet["entities"]["urls"]:
         if url["expanded_url"]:
-            print url["expanded_url"]
+            baseurl = url["expanded_url"]
         else:
-            print url
+            baseurl = url
+        if baseurl.startswith(shorteners):
+        	resp = requests.head(baseurl)
+        	if "Location" in resp.headers:
+        		print resp.headers["Location"]
+        	else:
+        		print baseurl
+        else:
+	        print baseurl


### PR DESCRIPTION
Sometimes the expanded_url in a tweet's json is still a shortened url: a t.co url in the tweet might expand to a bit.ly url. This enhancement looks for domains of common url shorteners in the expanded_url (or in the plain url if there is no expanded_url), and if it finds one it does an HTTP HEAD to discover the source url. (I was mostly interested in finding hidden GitHub links.) It could be improved by making the list of shorteners configurable.
