### PR TITLE
add utility to list image URLs from tweet json

### DIFF
--- a/utils/image_urls.py
+++ b/utils/image_urls.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+"""
+Print out the URLs of images uploaded to Twitter in a tweet json stream.
+Useful for piping to wget or curl to mass download. In Bash:
+
+% wget $(./utils/image_urls.py tweets.json)
+"""
+
+import json
+import fileinput
+
+for line in fileinput.input():
+    tweet = json.loads(line)
+    if 'media' in tweet['entities']:
+        for media in tweet['entities']['media']:
+            if media['type'] == 'photo':
+                print media['media_url']


### PR DESCRIPTION
I don't know if you'll find this useful enough to include, but I've used it to bulk download images:

``` sh
> wget $(./utils/image_urls.py tweets.json)
```
