### PR TITLE
Fix missing import for scrape mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 python-dateutil
+requests
 requests_oauthlib

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
     scripts = ['twarc.py'],
     description = 'command line utility to archive Twitter search results as line-oriented-json', 
     cmdclass = {'test': PyTest},
-    install_requires = ['oauth2', 'python-dateutil', 'requests_oauthlib'],
+    install_requires = ['oauth2', 'python-dateutil', 'requests', 'requests_oauthlib'],
     tests_require=['pytest']
 )

--- a/twarc.py
+++ b/twarc.py
@@ -9,6 +9,7 @@ import oauth2
 import urllib
 import logging
 import argparse
+import requests
 from requests_oauthlib import OAuth1Session
 
 


### PR DESCRIPTION
When trying to run `twarc --scrape hashtag`, I ran into an issue where a missing explicit import for `requests` was leading to the error below. This fixes that by adding `requests` as an explicit import and an explicit requirement.

```
$ CONSUMER_KEY="foo" CONSUMER_SECRET="bar" ACCESS_TOKEN="baz" ACCESS_TOKEN_SECRET="quux" twarc.py --scrape hashtag
Traceback (most recent call last):
  File "/usr/local/bin/twarc.py", line 5, in <module>
    pkg_resources.run_script('twarc==0.0.7', 'twarc.py')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 499, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1235, in run_script
    execfile(script_filename, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/twarc-0.0.7-py2.7.egg/EGG-INFO/scripts/twarc.py", line 287, in <module>
    archive(args.query, tweets)
  File "/usr/local/lib/python2.7/dist-packages/twarc-0.0.7-py2.7.egg/EGG-INFO/scripts/twarc.py", line 201, in archive
    for status in statuses:
  File "/usr/local/lib/python2.7/dist-packages/twarc-0.0.7-py2.7.egg/EGG-INFO/scripts/twarc.py", line 123, in search
    for status in scrape_tweets(q, max_id=max_id):
  File "/usr/local/lib/python2.7/dist-packages/twarc-0.0.7-py2.7.egg/EGG-INFO/scripts/twarc.py", line 214, in scrape_tweets
    for tweet_id in scrape_tweet_ids(query, max_id, sleep=1):
  File "/usr/local/lib/python2.7/dist-packages/twarc-0.0.7-py2.7.egg/EGG-INFO/scripts/twarc.py", line 237, in scrape_tweet_ids
    r = requests.get(url, params=q)
NameError: global name 'requests' is not defined
```
