### PR TITLE
Utils to dedupe and sort by ID (date)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ twarc
 [![Build Status](https://secure.travis-ci.org/edsu/twarc.png)](http://travis-ci.org/edsu/twarc)
 
 twarc is command line tool for archiving the tweets in a Twitter search result.
-Twitter search results live for a week or so, and are highly volatile. Results 
-are stored as line-oriented JSON (each line is a complete JSON document), and 
-are exactly what is received from the Twitter API.  twarc handles rate limiting 
+Twitter search results live for a week or so, and are highly volatile. Results
+are stored as line-oriented JSON (each line is a complete JSON document), and
+are exactly what is received from the Twitter API.  twarc handles rate limiting
 and paging through large result sets. It also handles repeated runs of the same
-query, by using the most recent tweet in the last run to determine when to 
+query, by using the most recent tweet in the last run to determine when to
 stop.
 
 twarc was originally created to save [tweets related to Aaron Swartz](http://archive.org/details/AaronswRelatedTweets).
@@ -30,7 +30,7 @@ stream you can run in stream mode:
 
 ## Use as a Library
 
-If you want you can use twarc to get a stream of tweets from a search as JSON 
+If you want you can use twarc to get a stream of tweets from a search as JSON
 and do something else with them. It will handle paging through results and
 quotas:
 
@@ -44,19 +44,19 @@ for tweet in twarc.search("aaronsw"):
 
 ## Scrape Mode
 
-The first time you fetch tweets for a query if you pass the --scrape option 
-it will use [search.twitter.com](http://search.twitter.com) to discover tweet 
+The first time you fetch tweets for a query if you pass the --scrape option
+it will use [search.twitter.com](http://search.twitter.com) to discover tweet
 ids, and then use the Twitter REST API to fetch the JSON for each tweet. This
-is an expensive operation because each ID needs to be fetched from the API 
+is an expensive operation because each ID needs to be fetched from the API
 which counts as a request against your quota.
 
 [Twitter Search](http://search.twitter.com) [now supports](http://blog.twitter.com/2013/02/now-showing-older-tweets-in-search.html) drilling backwards in time, past the week cutoff of the REST API. Since individual tweets are still retrieved with the REST API, rate limits apply--so this is quite a slow process. Still, if you are willing to let it run for a while it can be useful to query for older tweets, until the official search REST API supports a more historical perspective.
 
 ## Utils
 
-In the utils directory there are some simple command line utilities for 
-working with the json dumps like printing out the archived tweets as text 
-or html, extracting the usernames, referenced urls, and the like.  If you 
+In the utils directory there are some simple command line utilities for
+working with the json dumps like printing out the archived tweets as text
+or html, extracting the usernames, referenced urls, and the like.  If you
 create a script that is handy please send me a pull request :-)
 
 For example lets say you want to create a wall of tweets that mention 'nasa':
@@ -73,16 +73,16 @@ Or you want to create a word cloud of tweets you collected about nasa:
     % ./twarc.py nasa
     % utils/wordcloud.py nasa-20130306102105.json > nasa-wordcloud.html
 
-Or if you want to filter out all the tweets that look like they were from 
+Or if you want to filter out all the tweets that look like they were from
 women, and create a word cloud from them:
 
     % ./twarc.py nasa
     % utils/gender.py --gender female nasa-20130306102105.json | utils/wordcloud.py > nasa-female.html
-    
+
 Or if you want to create a [D3](http://d3js.org/) directed graph of mentions
-or retweets, in which nodes are users and arrows point from the original user 
+or retweets, in which nodes are users and arrows point from the original user
 to the user who mentions or retweets them:
-	
+
 	% ./twarc.py nasa
 	% utils/directed.py --mode mentions nasa-20130306102105.json > nasa-directed-mentions.html
 	% utils/directed.py --mode retweets nasa-20130306102105.json > nasa-directed-retweets.html
@@ -93,6 +93,15 @@ Or if you want to output [GeoJSON](http://geojson.org/) from tweets where geo co
     % ./twarc.py nasa
     % utils/geojson.py nasa-20130306102105.json > nasa-20130306102105.geojson
 
+Or if you have duplicate tweets in your JSON, deduplicate using:
+
+    % ./twarc.py --scrape nasa
+    % utils/deduplicate.py nasa-20130306102105.json > deduped.json
+
+Or if you want to sort by ID, which is analogous to sorting by time:
+
+    % ./twarc.py --scrape nasa
+    % utils/sort_by_id.py nasa-20130306102105.json > sorted.json
 
 License
 -------

--- a/utils/deduplicate.py
+++ b/utils/deduplicate.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+Given a JSON file, remove any tweets with duplicate IDs.
+
+(`twarc.py --scrape` may result in duplicate tweets.)
+
+Example usage:
+utils/deduplicate.py tweets.json > tweets_deduped.json
+"""
+from __future__ import print_function
+import json
+import fileinput
+from collections import OrderedDict
+
+seen = OrderedDict()
+for line in fileinput.input():
+    tweet = json.loads(line)
+
+    id = tweet["id"]
+    if id not in seen:
+        seen[id] = tweet
+
+for tweet in seen.values():
+    print(json.dumps(tweet))
+
+# End of file

--- a/utils/sort_by_id.py
+++ b/utils/sort_by_id.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+Sort tweets by ID.
+
+Twitter IDs are generated in chronologically ascending order,
+so this is the same as sorting by date.
+
+The output of `twarc --scrape` isn't necessarily in strict (reverse)
+chronological order.
+
+Example usage:
+utils/sort_by_id.py tweets.json > sorted.json
+"""
+from __future__ import print_function
+
+import sys
+import json
+from operator import itemgetter
+import fileinput
+import dateutil.parser
+
+
+tweets = []
+for line in fileinput.input():
+    tweet = json.loads(line)
+    tweets.append(tweet)
+
+tweets = sorted(tweets, key=itemgetter('id'))
+
+for tweet in tweets:
+    print(json.dumps(tweet))
+
+# End of file


### PR DESCRIPTION
Two extra utilities:
- `twarc.py --scrape` resulted in some duplicate tweets. `deduplicate.py` reduced it from 945 to 734. Use like: `utils/deduplicate.py tweets.json > tweets_deduped.json`
- The output of `twarc.py --scrape` was roughly in reverse chronological order, but not exactly. `sort_by_id.py` sorts by ID, which is analogous to sorting by time. Use like: `utils/sort_by_id.py tweets.json > sorted.json`
