### PR TITLE
Build using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ after_script:
 - pep8 --statistics --count *.py
 - pyflakes *.py | tee >(wc -l)
 
+after_failure:
+- cat test.log
+
 env:
   global:
   - secure: Y/ewo8nlTIZ38vYSY8/l2OsOhngjQOZps2W4gbY4b2EM1HaW7Ja9bRZbT/N6Q4HuhXsqVAawCrBJgaQrhU4KosEeajXLTMr2yXCb/EHFQIFI0FFY2ZOX2vJsUfpFpg9cCRhpr3CeGXPullFmrDUzF1BoEyrvthgqzRfuTXEcYqo=


### PR DESCRIPTION
This should result in quicker builds, at least things like quicker build startup, faster builds, more RAM and CPU:

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Enabled with `sudo: false`.

The main test bit is network dependent, so it probably won't affect that. But might as well get all the benefits available.

I also added verbose for the tests so you can see which pass/fail, and print the test log on failures. This didn't actually trigger for the timeouts, but may be useful in the future.
