### PR TITLE
Python 3.6 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 python:
 - '2.7'
-- '3.4'
+- '3.6'
 - '3.5'
+- '3.4'
 language: python
 install:
 - python setup.py install


### PR DESCRIPTION
We're also probably more interested in Python 3.6 pass/fail before than Python 3.4.