### PR TITLE
Avoid HTTPS certificate error

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Each tweet is represented as a JSON object that is
 the Twitter API.  Tweets are stored as line-oriented JSON.  Twarc will handle
 Twitter API's [rate limits](https://dev.twitter.com/rest/public/rate-limiting)
 for you. In addition to letting you collect tweets Twarc can also help you
-collect users, trends and hydrate tweet ids. 
+collect users, trends and hydrate tweet ids.
 
-twarc was developed as part of the [Documenting the Now](https://www.docnow.io)
+twarc was developed as part of the [Documenting the Now](http://www.docnow.io)
 project which was funded by the [Mellon Foundation](https://mellon.org/).
 
 ## Install
@@ -50,7 +50,7 @@ See below for the details about these commands and more.
 Once you've got your application keys you can tell twarc what they are with the
 `configure` command.
 
-    twarc configure 
+    twarc configure
 
 This will store your credentials in a file called `.twarc` in your home
 directory so you don't have to keep entering them in. If you would rather supply
@@ -63,7 +63,7 @@ options (`--consumer_key`, `--consumer_secret`, `--access_token`,
 
 The uses Twitter's [search/tweets](https://dev.twitter.com/rest/reference/get/search/tweets) to download *pre-existing* tweets matching a given query.
 
-    twarc search blacklivesmatter > tweets.json 
+    twarc search blacklivesmatter > tweets.json
 
 It's important to note that `search` will return tweets that are found within a
 7 day window that Twitter's search API imposes. If this seems like a small
@@ -91,7 +91,7 @@ Missouri:
 
 If a search query isn't supplied when using `--geocode` you will get all tweets
 relevant for that location and radius:
-    
+
     twarc search --geocode 38.7442,-90.3054,1mi > tweets.json
 
 ### Filter

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -4,19 +4,19 @@ twarc
 [![Build Status](https://secure.travis-ci.org/DocNow/twarc.png)](http://travis-ci.org/DocNow/twarc)
 
 twarc é uma ferramenta de linha de comando e usa a biblioteca Python para arquivamento de dados do Twitter com JSON.
-Cada tweet será representado como um objeto JSON 
+Cada tweet será representado como um objeto JSON
 [exatamente](https://dev.twitter.com/overview/api/tweets) o que foi devolvido pela
 API do Twitter.  Os Tweets serão armazenados como JSON, um por linha.  Twarc controla totalmente a API [limites de uso](https://dev.twitter.com/rest/public/rate-limiting)
 para você. Além de permitir que você colete Tweets, Twarc também pode ajudá-lo
-Coletar usuários, tendências e hidratar tweet ids. 
+Coletar usuários, tendências e hidratar tweet ids.
 
-twarc Foi desenvolvido como parte [Documenting the Now](https://www.docnow.io)
+twarc Foi desenvolvido como parte [Documenting the Now](http://www.docnow.io)
 Projecto financiado pelo [Mellon Foundation](https://mellon.org/).
 
 ## Instalação
 
 Antes de usar twarc você precisa registrar um aplicativo em
-[apps.twitter.com](http://apps.twitter.com). Depois de criar o aplicativo, anote a [consumer_key], [consumer_secret] e clique em  Gerar um [access_token] e um [access_token_secret]. Com estas quatro variáveis na mão você está pronto para começar a usar twarc. 
+[apps.twitter.com](http://apps.twitter.com). Depois de criar o aplicativo, anote a [consumer_key], [consumer_secret] e clique em  Gerar um [access_token] e um [access_token_secret]. Com estas quatro variáveis na mão você está pronto para começar a usar twarc.
 OBS: Se tiver alguma dúvida de como criar o aplicativo, consulte [como criar um app](http://blog.difluir.com/2013/06/como-criar-uma-app-no-twitter/)
 
 1. instalação [Python](http://python.org/download) (2 ou 3)
@@ -42,23 +42,23 @@ Veja abaixo os detalhes sobre esses comandos e muito mais.
 
 ### Configurar
 
-Uma vez que você tem suas chaves de aplicativo, você pode dizer ao twarc quais são com o comando 
+Uma vez que você tem suas chaves de aplicativo, você pode dizer ao twarc quais são com o comando
 `configure`.
 
-    twarc configure 
+    twarc configure
 
-Isso irá armazenar as credenciais em um arquivo chamado `.twarc` em seu 
+Isso irá armazenar as credenciais em um arquivo chamado `.twarc` em seu
 diretório home. Este arquivo será usado como padrão em outras chamadas.
 Se preferir, você pode fornecer diretamente as chaves (`CONSUMER_KEY`,
-`CONSUMER_SECRET`, `ACCESS_TOKEN`, `ACCESS_TOKEN_SECRET`) ou usando a linha de comando 
+`CONSUMER_SECRET`, `ACCESS_TOKEN`, `ACCESS_TOKEN_SECRET`) ou usando a linha de comando
 com as opções (`--consumer_key`, `--consumer_secret`, `--access_token`,
 `--access_token_secret`).
 
-### Pesquisar 
+### Pesquisar
 
 Os usuários do Twitter [Pesquisar/tweets](https://dev.twitter.com/rest/reference/get/search/tweets) para baixar *pre-existing* tweets, correspondendo a uma determinada consulta que desejar.
 
-    twarc search blacklivesmatter > tweets.json 
+    twarc search blacklivesmatter > tweets.json
 
 É importante notar que `search` Irá retornar tweets encontrados dentro de uma
 Janela de 7 dias imposta pela API de pesquisa do Twitter. Se isso parece uma pequena
@@ -85,7 +85,7 @@ Mencionando *foratemer* das pessoas situadas a 1 milha na região de Brasília:
 
 Se uma consulta de pesquisa não for fornecida`--geocode` Você receberá todos os tweets
 Relevantes para esse local e raio:
-    
+
     twarc search --geocode -16.050561,-47.814708,1mi > tweets.json
 
 ### Filter
@@ -104,23 +104,23 @@ coletar tweets e os retweets da CNN:
 
     twarc filter --follow 759251 > tweets.json
 
-Você também pode coletar tweets usando uma caixa delimitadora. 
-Nota: o traço principal precisa ser escapado na caixa delimitadora ou então 
+Você também pode coletar tweets usando uma caixa delimitadora.
+Nota: o traço principal precisa ser escapado na caixa delimitadora ou então
 ele será interpretado como um comando de linha como argumento!
 Exemplo: escapando com a barra invertida após aspas "\
 
     twarc filter --locations "\-74,40,-73,41" > tweets.json
 
 
-Se você combinar opções eles serão um OU outro juntos. 
-Por exemplo, isso irá coletar Tweets que usam o hashtags foratemer 
+Se você combinar opções eles serão um OU outro juntos.
+Por exemplo, isso irá coletar Tweets que usam o hashtags foratemer
 OU blm e também tweets do usuário CNN:
 
     twarc filter blacklivesmatter,blm --follow 759251 > tweets.json
 
 ### Sample
 
-Use o comando de linha `sample` para ouvir/Status do Twitter [statuses/sample](https://dev.twitter.com/streaming/reference/get/statuses/sample) API para uma amostra "aleatória/ramdom" de tweets  públicos recentes. O status será do usuário ativo na API twarc. 
+Use o comando de linha `sample` para ouvir/Status do Twitter [statuses/sample](https://dev.twitter.com/streaming/reference/get/statuses/sample) API para uma amostra "aleatória/ramdom" de tweets  públicos recentes. O status será do usuário ativo na API twarc.
 
     twarc sample > tweets.json
 
@@ -153,7 +153,7 @@ O comando `followers` Vai usar o Twitter [API seguidores ID](https://dev.twitter
 
     twarc followers deray > follower_ids.txt
 
-O resultado incluirá exatamente um ID de usuário por linha. 
+O resultado incluirá exatamente um ID de usuário por linha.
 A ordem de resposta é Invertida cronológicamente, o mais recente seguidores em primeiro lugar.
 
 ### Amigos (Quem eu sigo)
@@ -162,7 +162,7 @@ Igual o comando `followers`, o comando` friends` usará o Twitter [API amigos ID
 
     twarc friends deray > friend_ids.txt
 
-### Trends / tendências 
+### Trends / tendências
 
 O comando `trends` permite recuperar informações da API do Twitter sobre hashtags tendências. Você precisa fornecer um  [Onde na Terra](http://developer.yahoo.com/geo/geoplanet/) identificador (`woeid`) para indicar quais as tendências que você está interessado. Por exemplo, aqui é como você pode obter as tendências atuais para St Louis:
 
@@ -195,9 +195,9 @@ Você também pode procurar usuários usando um id de usuário:
 
 ## Usar twarc como uma biblioteca
 
-Se você quiser pode usar `twarc` programaticamente como uma biblioteca 
-para coletar Tweets. Primeiro você precisa criar uma instância do `Twarc` 
-(usando as suas Credenciais do Twitter) e, em seguida, usá-lo para iterar 
+Se você quiser pode usar `twarc` programaticamente como uma biblioteca
+para coletar Tweets. Primeiro você precisa criar uma instância do `Twarc`
+(usando as suas Credenciais do Twitter) e, em seguida, usá-lo para iterar
 através de resultados de pesquisa ou filtrar resultados de pesquisa.
 
 ```python
@@ -208,7 +208,7 @@ for tweet in t.search("ferguson"):
     print(tweet["text"])
 ```
 
-Você pode fazer o mesmo para um fluxo de filtro de novos tweets que 
+Você pode fazer o mesmo para um fluxo de filtro de novos tweets que
 correspondem a uma determinada faixa usando palavra-chave.
 
 ```python
@@ -230,7 +230,7 @@ for tweet in t.filter(follow='12345,678910'):
     print(tweet["text"])
 ```
 
-Da mesma forma você pode hidratar os identificadores de tweet passando 
+Da mesma forma você pode hidratar os identificadores de tweet passando
 em uma lista de ids ou um gerador:
 
 ```python
@@ -241,11 +241,11 @@ for tweet in t.hydrate(open('ids.txt')):
 ## Utilitários
 
 No diretório utils existem alguns utilitários via linha de comando simples para
-Trabalhar com o JSON gravando linha por por linha, tais como. 
-- Imprimir os tweets arquivados como Texto ou html. 
-- Extraindo os nomes de usuários. 
-- URLs referenciadas. 
-- Etc. 
+Trabalhar com o JSON gravando linha por por linha, tais como.
+- Imprimir os tweets arquivados como Texto ou html.
+- Extraindo os nomes de usuários.
+- URLs referenciadas.
+- Etc.
 Se você criar um Script e achar útil, por favor envie um pedido de pull no github do projeto.
 
 Quando você tem alguns tweets você pode criar um paralelo rudimentar deles:
@@ -314,7 +314,7 @@ Depois de desfazer masca de seus URLs, você pode obter uma lista classificada d
 
 ## twarc-report
 
-Alguns scripts de utilitários adicionais para gerar saída csv ou json adequada foi 
+Alguns scripts de utilitários adicionais para gerar saída csv ou json adequada foi
 feito com [D3.js](http://d3js.org/) Visualizações são encontradas
 [twarc-report](https://github.com/pbinkley/twarc-report) projeto. O
 Util direct.py, anteriormente parte do twarc, mudou-se para twarc-report como


### PR DESCRIPTION
Visiting https://www.docnow.io results in a certificate error:

![image](https://cloud.githubusercontent.com/assets/1324225/21952793/b9860c46-da2d-11e6-8418-695940c98cbc.png)

![image](https://cloud.githubusercontent.com/assets/1324225/21952794/c0ff7f70-da2d-11e6-974c-7a541cbd1d11.png)

![image](https://cloud.githubusercontent.com/assets/1324225/21952801/fe623254-da2d-11e6-8520-07bcf0dbde3d.png)

Use http://www.docnow.io instead.