### PR TITLE
Added allow_404 kwargs to get retry

### DIFF
--- a/twarc.py
+++ b/twarc.py
@@ -813,6 +813,7 @@ class Twarc(object):
             else:
                 self.connect()
                 kwargs['connection_error_count'] = connection_error_count
+                kwargs['allow_404'] = allow_404
                 return self.get(*args, **kwargs)
 
     @rate_limit


### PR DESCRIPTION
Added allow_404 kwargs to get retry to avoid recursion problem for missing user lookups or timelines.