### PR TITLE
Adding timeline command to twarc-archive.py

### DIFF
--- a/utils/twarc-archive.py
+++ b/utils/twarc-archive.py
@@ -68,8 +68,7 @@ def main():
     parser.add_argument("--tweet_mode", action="store", default="compat",
                         dest="tweet_mode", choices=["compat", "extended"],
                         help="set tweet mode")
-    parser.add_argument("--twarc_command", action="store", default="search",
-                        dest="twarc_command", choices=["search", "timeline"],
+    parser.add_argument("--twarc_command", action="store", default="search", choices=["search", "timeline"],
                         help="select twarc command to be used for harvest, currently supports search and timeline")
 
     args = parser.parse_args()


### PR DESCRIPTION
I have added a twarc_command argument to twarc-archive.py. This allows users to pass either the search or timeline command to the twarc-archive.py script. If no additional argument is passed, it defaults to search. 