### PR TITLE
Set tweet mode when posting during hydrating.

### DIFF
--- a/twarc.py
+++ b/twarc.py
@@ -727,7 +727,7 @@ class Twarc(object):
             ids.append(tweet_id)
             if len(ids) == 100:
                 logging.info("hydrating %s ids", len(ids))
-                resp = self.post(url, data={"id": ','.join(ids)})
+                resp = self.post(url, data={"id": ','.join(ids), "tweet_mode": self.tweet_mode})
                 tweets = resp.json()
                 tweets.sort(key=lambda t: t['id_str'])
                 for tweet in tweets:
@@ -737,7 +737,7 @@ class Twarc(object):
         # hydrate any remaining ones
         if len(ids) > 0:
             logging.info("hydrating %s", ids)
-            resp = self.client.post(url, data={"id": ','.join(ids)})
+            resp = self.post(url, data={"id": ','.join(ids), "tweet_mode": self.tweet_mode})
             for tweet in resp.json():
                 yield tweet
 


### PR DESCRIPTION
Steps to reproduce:
```
 echo "847526347039789057" | python twarc.py --tweet_mode extended hydrate - | jq
```

Expected result:
An extended tweet

Actual result:
A classic tweet