### PR TITLE
Update docs to use .jsonl instead of .json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ twarc
 twarc is a command line tool and Python library for archiving Twitter JSON data.
 Each tweet is represented as a JSON object that is
 [exactly](https://dev.twitter.com/overview/api/tweets) what was returned from
-the Twitter API.  Tweets are stored as line-oriented JSON.  Twarc will handle
+the Twitter API.  Tweets are stored as [line-oriented JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON).  Twarc will handle
 Twitter API's [rate limits](https://dev.twitter.com/rest/public/rate-limiting)
 for you. In addition to letting you collect tweets Twarc can also help you
 collect users, trends and hydrate tweet ids.
@@ -35,11 +35,11 @@ First you're going to need to tell twarc about your API keys:
 
 Then try out a search:
 
-    twarc search blacklivesmatter > search.json
+    twarc search blacklivesmatter > search.jsonl
 
 Or maybe you'd like to collect tweets as they happen?
 
-    twarc filter blacklivesmatter > stream.json
+    twarc filter blacklivesmatter > stream.jsonl
 
 See below for the details about these commands and more.
 
@@ -63,7 +63,7 @@ options (`--consumer_key`, `--consumer_secret`, `--access_token`,
 
 The uses Twitter's [search/tweets](https://dev.twitter.com/rest/reference/get/search/tweets) to download *pre-existing* tweets matching a given query.
 
-    twarc search blacklivesmatter > tweets.json
+    twarc search blacklivesmatter > tweets.jsonl
 
 It's important to note that `search` will return tweets that are found within a
 7 day window that Twitter's search API imposes. If this seems like a small
@@ -76,29 +76,29 @@ pasting the resulting query from the search box. For example here is a more
 complicated query that searches for tweets containing either the
 \#blacklivesmatter or #blm hashtags that were sent to deray.
 
-    twarc search '#blacklivesmatter OR #blm to:deray' > tweets.json
+    twarc search '#blacklivesmatter OR #blm to:deray' > tweets.jsonl
 
 Twitter attempts to code the language of a tweet, and you can limit your search
 to a particular language if you want:
 
-    twarc search '#blacklivesmatter' --lang fr > tweets.json
+    twarc search '#blacklivesmatter' --lang fr > tweets.jsonl
 
 You can also search for tweets with a given location, for example tweets
 mentioning *blacklivesmatter* that are 1 mile from the center of Ferguson,
 Missouri:
 
-    twarc search blacklivesmatter --geocode 38.7442,-90.3054,1mi > tweets.json
+    twarc search blacklivesmatter --geocode 38.7442,-90.3054,1mi > tweets.jsonl
 
 If a search query isn't supplied when using `--geocode` you will get all tweets
 relevant for that location and radius:
 
-    twarc search --geocode 38.7442,-90.3054,1mi > tweets.json
+    twarc search --geocode 38.7442,-90.3054,1mi > tweets.jsonl
 
 ### Filter
 
 The `filter` command will use Twitter's [statuses/filter](https://dev.twitter.com/streaming/reference/post/statuses/filter) API to collect tweets as they happen.
 
-    twarc filter blacklivesmatter,blm > tweets.json
+    twarc filter blacklivesmatter,blm > tweets.jsonl
 
 Please note that the syntax for the Twitter's track queries is slightly
 different than what queries in their search API. So please consult the
@@ -108,38 +108,38 @@ Use the `follow` command line argument if you would like to collect tweets from
 a given user id as they happen. This includes retweets. For example this will
 collect tweets and retweets from CNN:
 
-    twarc filter --follow 759251 > tweets.json
+    twarc filter --follow 759251 > tweets.jsonl
 
 You can also collect tweets using a bounding box. Note: the leading dash needs
 to be escaped in the bounding box or else it will be interpreted as a command
 line argument!
 
-    twarc filter --locations "\-74,40,-73,41" > tweets.json
+    twarc filter --locations "\-74,40,-73,41" > tweets.jsonl
 
 
 If you combine options they are OR'ed together. For example this will collect
 tweets that use the blacklivesmatter or blm hashtags and also tweets from user
 CNN:
 
-    twarc filter blacklivesmatter,blm --follow 759251 > tweets.json
+    twarc filter blacklivesmatter,blm --follow 759251 > tweets.jsonl
 
 ### Sample
 
 Use the `sample` command to listen to Twitter's [statuses/sample](https://dev.twitter.com/streaming/reference/get/statuses/sample) API for a "random" sample of recent public statuses.
 
-    twarc sample > tweets.json
+    twarc sample > tweets.jsonl
 
 ### Dehydrate
 
 The `dehydrate` command generates an id list from a file of tweets:
 
-    twarc dehydrate tweets.json > tweet-ids.txt
+    twarc dehydrate tweets.jsonl > tweet-ids.txt
 
 ### Hydrate
 
 Twarc's `hydrate` command will read a file of tweet identifiers and write out the tweet JSON for them using Twitter's [status/lookup](https://dev.twitter.com/rest/reference/get/statuses/lookup) API.
 
-    twarc hydrate ids.txt > tweets.json
+    twarc hydrate ids.txt > tweets.jsonl
 
 Twitter API's [Terms of Service](https://dev.twitter.com/overview/terms/policy#6._Be_a_Good_Partner_to_Twitter) discourage people from making large amounts of raw Twitter data available on the Web.  The data can be used for research and archived for local use, but not shared with the world. Twitter does allow files of tweet identifiers to be shared, which can be useful when you would like to make a dataset of tweets available.  You can then use Twitter's API to *hydrate* the data, or to retrieve the full JSON for each identifier. This is particularly important for [verification](https://en.wikipedia.org/wiki/Reproducibility) of social media research.
 
@@ -147,16 +147,16 @@ Twitter API's [Terms of Service](https://dev.twitter.com/overview/terms/policy#6
 
 The `users` command will return User metadata for the given screen names.
 
-    twarc users deray,Nettaaaaaaaa > users.json
+    twarc users deray,Nettaaaaaaaa > users.jsonl
 
 You can also give it user ids:
 
-    twarc users 1232134,1413213 > users.json
+    twarc users 1232134,1413213 > users.jsonl
 
 If you want you can also use a file of user ids, which can be useful if you are
 using the `followers` and `friends` commands below:
 
-    twarc users ids.txt > users.json
+    twarc users ids.txt > users.jsonl
 
 ### Followers
 
@@ -198,21 +198,21 @@ Behind the scenes twarc will lookup the location using Twitter's [trends/closest
 
 The timeline command will use Twitter's [user timeline API](https://dev.twitter.com/rest/reference/get/statuses/user_timeline) to collect the most recent tweets posted by the user indicated by screen_name.
 
-    twarc timeline deray > tweets.json
+    twarc timeline deray > tweets.jsonl
 
 You can also look up users using a user id:
 
-    twarc timeline 12345 > tweets.json
+    twarc timeline 12345 > tweets.jsonl
 
 ### Retweets and Replies
 
 You can get retweets for a given tweet id like so:
 
-    twarc retweets 824077910927691778 > retweets.json
+    twarc retweets 824077910927691778 > retweets.jsonl
 
-If you want to get the replies to a given tweet you can: 
+If you want to get the replies to a given tweet you can:
 
-    twarc replies 824077910927691778 > replies.json
+    twarc replies 824077910927691778 > replies.jsonl
 
 Using the `--recursive` option will also fetch replies to the replies as well as
 quotes.  This can take a long time to complete for a large thread because of
@@ -279,81 +279,81 @@ script that you find handy please send a pull request.
 
 When you've got some tweets you can create a rudimentary wall of them:
 
-    % utils/wall.py tweets.json > tweets.html
+    % utils/wall.py tweets.jsonl > tweets.html
 
 You can create a word cloud of tweets you collected about nasa:
 
-    % utils/wordcloud.py tweets.json > wordcloud.html
+    % utils/wordcloud.py tweets.jsonl > wordcloud.html
 
 If you've collected some tweets using `replies` you can create a static D3
 visualization of them with:
 
-    % utils/network.py tweets.json tweets.html
+    % utils/network.py tweets.jsonl tweets.html
 
 Optionally you can consolidate tweets by user, allowing you to see central accounts:
 
-    % utils/network.py --users tweets.json tweets.html
+    % utils/network.py --users tweets.jsonl tweets.html
 
 And if you want to use the network graph in a program like [Gephi](https://gephi.org/),
 you can generate a GEXF file with the following:
 
-    % utils/network.py --users tweets.json tweets.gexf
+    % utils/network.py --users tweets.jsonl tweets.gexf
 
 gender.py is a filter which allows you to filter tweets based on a guess about
 the gender of the author. So for example you can filter out all the tweets that
 look like they were from women, and create a word cloud for them:
 
-    % utils/gender.py --gender female tweets.json | utils/wordcloud.py > tweets-female.html
+    % utils/gender.py --gender female tweets.jsonl | utils/wordcloud.py > tweets-female.html
 
 You can output [GeoJSON](http://geojson.org/) from tweets where geo coordinates are available:
 
-    % utils/geojson.py tweets.json > tweets.geojson
+    % utils/geojson.py tweets.jsonl > tweets.geojson
 
 Optionally you can export GeoJSON with centroids replacing bounding boxes:
 
-    % utils/geojson.py tweets.json --centroid > tweets.geojson
+    % utils/geojson.py tweets.jsonl --centroid > tweets.geojson
 
 And if you do export GeoJSON with centroids, you can add some random fuzzing:
 
-    % utils/geojson.py tweets.json --centroid --fuzz 0.01 > tweets.geojson
+    % utils/geojson.py tweets.jsonl --centroid --fuzz 0.01 > tweets.geojson
 
 To filter tweets by presence or absence of geo coordinates (or Place, see [API documentation](https://dev.twitter.com/overview/api/places)):
 
-    % utils/geofilter.py tweets.json --yes-coordinates > tweets-with-geocoords.json
-    % cat tweets.json | utils/geofilter.py --no-place > tweets-with-no-place.json
+    % utils/geofilter.py tweets.jsonl --yes-coordinates > tweets-with-geocoords.jsonl
+    % cat tweets.jsonl | utils/geofilter.py --no-place > tweets-with-no-place.jsonl
 
 To filter tweets by a GeoJSON fence (requires [Shapely](https://github.com/Toblerity/Shapely)):
 
-    % utils/geofilter.py tweets.json --fence limits.geojson > fenced-tweets.json
-    % cat tweets.json | utils/geofilter.py --fence limits.geojson > fenced-tweets.json
+    % utils/geofilter.py tweets.jsonl --fence limits.geojson > fenced-tweets.jsonl
+    % cat tweets.jsonl | utils/geofilter.py --fence limits.geojson > fenced-tweets.jsonl
 
 If you suspect you have duplicate in your tweets you can dedupe them:
 
-    % utils/deduplicate.py tweets.json > deduped.json
+    % utils/deduplicate.py tweets.jsonl > deduped.jsonl
 
 You can sort by ID, which is analogous to sorting by time:
 
-    % utils/sort_by_id.py tweets.json > sorted.json
+    % utils/sort_by_id.py tweets.jsonl > sorted.jsonl
 
 You can filter out all tweets before a certain date (for example, if a hashtag was used for another event before the one you're interested in):
 
-    % utils/filter_date.py --mindate 1-may-2014 tweets.json > filtered.json
+    % utils/filter_date.py --mindate 1-may-2014 tweets.jsonl > filtered.jsonl
 
 You can get an HTML list of the clients used:
 
-    % utils/source.py tweets.json > sources.html
+    % utils/source.py tweets.jsonl > sources.html
 
 If you want to remove the retweets:
 
-    % utils/noretweets.py tweets.json > tweets_noretweets.json
+    % utils/noretweets.py tweets.jsonl > tweets_noretweets.jsonl
 
 Or unshorten urls (requires [unshrtn](https://github.com/edsu/unshrtn)):
 
-    % cat tweets.json | utils/unshorten.py > unshortened.json
+    % cat tweets.jsonl | utils/unshorten.py > unshortened.jsonl
 
 Once you unshorten your URLs you can get a ranked list of most-tweeted URLs:
 
-    % cat unshortened.json | utils/urls.py | sort | uniq -c | sort -nr > urls.txt
+    % cat unshortened.jsonl | utils/urls.py | sort | uniq -c | sort -nr > urls.txt
 
 ## twarc-report
 

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -6,7 +6,7 @@ twarc
 twarc é uma ferramenta de linha de comando e usa a biblioteca Python para arquivamento de dados do Twitter com JSON.
 Cada tweet será representado como um objeto JSON
 [exatamente](https://dev.twitter.com/overview/api/tweets) o que foi devolvido pela
-API do Twitter.  Os Tweets serão armazenados como JSON, um por linha.  Twarc controla totalmente a API [limites de uso](https://dev.twitter.com/rest/public/rate-limiting)
+API do Twitter.  Os Tweets serão armazenados como [JSON, um por linha](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON).  Twarc controla totalmente a API [limites de uso](https://dev.twitter.com/rest/public/rate-limiting)
 para você. Além de permitir que você colete Tweets, Twarc também pode ajudá-lo
 Coletar usuários, tendências e hidratar tweet ids.
 
@@ -30,11 +30,11 @@ Primeiro você vai precisar configurar o twarc mostrando a ele suas chaves de AP
 
 Em seguida, experimente uma pesquisa rápida:
 
-    twarc search blacklivesmatter > search.json
+    twarc search blacklivesmatter > search.jsonl
 
 Ou talvez você gostaria de coletar tweets como eles acontecem?
 
-    twarc filter blacklivesmatter > stream.json
+    twarc filter blacklivesmatter > stream.jsonl
 
 Veja abaixo os detalhes sobre esses comandos e muito mais.
 
@@ -58,7 +58,7 @@ com as opções (`--consumer_key`, `--consumer_secret`, `--access_token`,
 
 Os usuários do Twitter [Pesquisar/tweets](https://dev.twitter.com/rest/reference/get/search/tweets) para baixar *pre-existing* tweets, correspondendo a uma determinada consulta que desejar.
 
-    twarc search blacklivesmatter > tweets.json
+    twarc search blacklivesmatter > tweets.jsonl
 
 É importante notar que `search` Irá retornar tweets encontrados dentro de uma
 Janela de 7 dias imposta pela API de pesquisa do Twitter. Se isso parece uma pequena
@@ -71,28 +71,28 @@ colar a consulta resultante da caixa de pesquisa. Por exemplo, aqui está uma
 consulta complicada que procura por tweets que contenham
 \#blacklivesmatter ou #blm hashtags que foram enviados para deray.
 
-    twarc search '#blacklivesmatter OR #blm to:deray' > tweets.json
+    twarc search '#blacklivesmatter OR #blm to:deray' > tweets.jsonl
 
 O Twitter tenta codificar o idioma de um tweet ou você pode limitar sua pesquisa.
 Para um idioma específico caso você queira só português:
 
-    twarc search '#foratemer' --lang pt > tweets.json
+    twarc search '#foratemer' --lang pt > tweets.jsonl
 
 Você também pode pesquisar tweets com um determinado local, por exemplo tweets
 Mencionando *foratemer* das pessoas situadas a 1 milha na região de Brasília:
 
-    twarc search foratemer --geocode -16.050561,-47.814708,1mi > tweets.json
+    twarc search foratemer --geocode -16.050561,-47.814708,1mi > tweets.jsonl
 
 Se uma consulta de pesquisa não for fornecida`--geocode` Você receberá todos os tweets
 Relevantes para esse local e raio:
 
-    twarc search --geocode -16.050561,-47.814708,1mi > tweets.json
+    twarc search --geocode -16.050561,-47.814708,1mi > tweets.jsonl
 
 ### Filter
 
 O comando `filter` Vai usar o Twitter [statuses/filter](https://dev.twitter.com/streaming/reference/post/statuses/filter) API to collect tweets as they happen.
 
-    twarc filter foratemer,blm > tweets.json
+    twarc filter foratemer,blm > tweets.jsonl
 
 Observe que a sintaxe para consultas de queries do Twitter é ligeiramente
 diferente do que as consultas em sua API de pesquisa. Por favor, consulte a
@@ -102,33 +102,33 @@ Use o comando de linha `follow` com argumento se você quer coletar tweets de
 um determinado ID de usuário. Isso inclui retweets. Por exemplo, isso vai
 coletar tweets e os retweets da CNN:
 
-    twarc filter --follow 759251 > tweets.json
+    twarc filter --follow 759251 > tweets.jsonl
 
 Você também pode coletar tweets usando uma caixa delimitadora.
 Nota: o traço principal precisa ser escapado na caixa delimitadora ou então
 ele será interpretado como um comando de linha como argumento!
 Exemplo: escapando com a barra invertida após aspas "\
 
-    twarc filter --locations "\-74,40,-73,41" > tweets.json
+    twarc filter --locations "\-74,40,-73,41" > tweets.jsonl
 
 
 Se você combinar opções eles serão um OU outro juntos.
 Por exemplo, isso irá coletar Tweets que usam o hashtags foratemer
 OU blm e também tweets do usuário CNN:
 
-    twarc filter blacklivesmatter,blm --follow 759251 > tweets.json
+    twarc filter blacklivesmatter,blm --follow 759251 > tweets.jsonl
 
 ### Sample
 
 Use o comando de linha `sample` para ouvir/Status do Twitter [statuses/sample](https://dev.twitter.com/streaming/reference/get/statuses/sample) API para uma amostra "aleatória/ramdom" de tweets  públicos recentes. O status será do usuário ativo na API twarc.
 
-    twarc sample > tweets.json
+    twarc sample > tweets.jsonl
 
 ### Hydrate
 
 O comando do Twarc `hydrate` Lê um arquivo de IDs de tweets identificados e escreve o tweet em JSON para eles usando Twitter [status/lookup](https://dev.twitter.com/rest/reference/get/statuses/lookup) API.
 
-    twarc hydrate ids.txt > tweets.json
+    twarc hydrate ids.txt > tweets.jsonl
 
 O [Termos do Serviço](https://dev.twitter.com/overview/terms/policy#6._Be_a_Good_Partner_to_Twitter) do Twitter API's desencoraja pessoas na busca de grandes quantidades de dados brutos do Twitter e disponíbilizar na Web. Os dados podem ser usados para pesquisa e arquivados para uso local, mas não devem ser compartilhados com o mundo. O Twitter permite que arquivos de identificadores de tweet sejam compartilhados, o que pode ser útil quando você quer fazer um conjunto de dados de tweets disponíveis. Você pode usar a API do Twitter para *hydrate* dados ou para recuperar o JSON completo para cada identificador/usuário ID. Isto é particularmente importante para [verificação](https://en.wikipedia.org/wiki/Reproducibility) da rede social mundial.
 
@@ -136,16 +136,16 @@ O [Termos do Serviço](https://dev.twitter.com/overview/terms/policy#6._Be_a_Goo
 
 O comando `users` retorna metadados do usuário fornecidos na tela,exemplo:
 
-    twarc users deray,Nettaaaaaaaa > users.json
+    twarc users deray,Nettaaaaaaaa > users.jsonl
 
 Você também pode usar os ids do usuário:
 
-    twarc users 1232134,1413213 > users.json
+    twarc users 1232134,1413213 > users.jsonl
 
 Se você quiser, você também pode usar um arquivo com ids de usuário, o que pode ser útil se você estiver
 usando o `followers` e o `friends` conforme comando abaixo:
 
-    twarc users ids.txt > users.json
+    twarc users ids.txt > users.jsonl
 
 ### Seguidores (Quem me segue)
 
@@ -187,11 +187,11 @@ Por trás das cenas, o twarc buscará o local usando o Twitter [trends/closest](
 
 O comando timeline usará do Twitter [API user timeline](https://dev.twitter.com/rest/reference/get/statuses/user_timeline) Para coletar os tweets mais recentes postados pelo usuário indicado por um screen_name.
 
-    twarc timeline deray > tweets.json
+    twarc timeline deray > tweets.jsonl
 
 Você também pode procurar usuários usando um id de usuário:
 
-    twarc timeline 12345 > tweets.json
+    twarc timeline 12345 > tweets.jsonl
 
 ## Usar twarc como uma biblioteca
 
@@ -250,67 +250,67 @@ Se você criar um Script e achar útil, por favor envie um pedido de pull no git
 
 Quando você tem alguns tweets você pode criar um paralelo rudimentar deles:
 
-    % utils/wall.py tweets.json > tweets.html
+    % utils/wall.py tweets.jsonl > tweets.html
 
 Você pode criar uma nuvem de palavras de tweets coletados sobre a nasa:
 
-    % utils/wordcloud.py tweets.json > wordcloud.html
+    % utils/wordcloud.py tweets.jsonl > wordcloud.html
 
 gender.py É um filtro que permite filtrar tweets com base em um palpite sobre
 o gênero do autor. Assim, por exemplo, você pode filtrar todos os tweets que
 em tese foram feitos por mulheres, e criar uma nuvem de palavras para eles:
 
-    % utils/gender.py --gender female tweets.json | utils/wordcloud.py > tweets-female.html
+    % utils/gender.py --gender female tweets.jsonl | utils/wordcloud.py > tweets-female.html
 
 Você pode com [GeoJSON](http://geojson.org/) ver os tweets de determinadas coordenadas geográficas:
 
-    % utils/geojson.py tweets.json > tweets.geojson
+    % utils/geojson.py tweets.jsonl > tweets.geojson
 
 Opcionalmente você pode exportar GeoJSON com centróides substituindo as caixas delimitadoras:
 
-    % utils/geojson.py tweets.json --centroid > tweets.geojson
+    % utils/geojson.py tweets.jsonl --centroid > tweets.geojson
 
 E se você exportar GeoJSON com centróides, você pode adicionar alguns fuzzing aleatórios:
 
-    % utils/geojson.py tweets.json --centroid --fuzz 0.01 > tweets.geojson
+    % utils/geojson.py tweets.jsonl --centroid --fuzz 0.01 > tweets.geojson
 
 Para filtrar tweets pela presença ou ausência de coordenadas geográficas (Ou Local, veja [Documentação da API locais](https://dev.twitter.com/overview/api/places)):
 
-    % utils/geofilter.py tweets.json --yes-coordinates > tweets-with-geocoords.json
-    % cat tweets.json | utils/geofilter.py --no-place > tweets-with-no-place.json
+    % utils/geofilter.py tweets.jsonl --yes-coordinates > tweets-with-geocoords.jsonl
+    % cat tweets.jsonl | utils/geofilter.py --no-place > tweets-with-no-place.jsonl
 
 Para filtrar tweets por uma área com GeoJSON (Requer [Shapely](https://github.com/Toblerity/Shapely)):
 
-    % utils/geofilter.py tweets.json --fence limits.geojson > fenced-tweets.json
-    % cat tweets.json | utils/geofilter.py --fence limits.geojson > fenced-tweets.json
+    % utils/geofilter.py tweets.jsonl --fence limits.geojson > fenced-tweets.jsonl
+    % cat tweets.jsonl | utils/geofilter.py --fence limits.geojson > fenced-tweets.jsonl
 
 Se você suspeitar ter duplicado seus tweets, você pode remove-los:
 
-    % utils/deduplicate.py tweets.json > deduped.json
+    % utils/deduplicate.py tweets.jsonl > deduped.jsonl
 
 Você pode classificar por ID, o que é análogo à classificação por tempo:
 
-    % utils/sort_by_id.py tweets.json > sorted.json
+    % utils/sort_by_id.py tweets.jsonl > sorted.jsonl
 
 Você pode filtrar todos os tweets antes de uma determinada data (por exemplo, se uma hashtag foi usada para outro evento antes do que você está interessado):
 
-    % utils/filter_date.py --mindate 1-may-2014 tweets.json > filtered.json
+    % utils/filter_date.py --mindate 1-may-2014 tweets.jsonl > filtered.jsonl
 
 Você pode obter uma lista HTML dos usuários usados:
 
-    % utils/source.py tweets.json > sources.html
+    % utils/source.py tweets.jsonl > sources.html
 
 Se você quiser remover os retweets:
 
-    % utils/noretweets.py tweets.json > tweets_noretweets.json
+    % utils/noretweets.py tweets.jsonl > tweets_noretweets.jsonl
 
 Ou unshorten urls (Requer [unshrtn](https://github.com/edsu/unshrtn)):
 
-    % cat tweets.json | utils/unshorten.py > unshortened.json
+    % cat tweets.jsonl | utils/unshorten.py > unshortened.jsonl
 
 Depois de desfazer masca de seus URLs, você pode obter uma lista classificada dos URLs mais tweeted:
 
-    % cat unshortened.json | utils/urls.py | sort | uniq -c | sort -nr > urls.txt
+    % cat unshortened.jsonl | utils/urls.py | sort | uniq -c | sort -nr > urls.txt
 
 ## twarc-report
 

--- a/utils/deduplicate.py
+++ b/utils/deduplicate.py
@@ -5,7 +5,7 @@ Given a JSON file, remove any tweets with duplicate IDs.
 (`twarc.py --scrape` may result in duplicate tweets.)
 
 Example usage:
-utils/deduplicate.py tweets.json > tweets_deduped.json
+utils/deduplicate.py tweets.jsonl > tweets_deduped.jsonl
 """
 
 from __future__ import print_function

--- a/utils/discover_ids.py
+++ b/utils/discover_ids.py
@@ -8,7 +8,7 @@ queries. Once you have the tweet ids for a given query you can hydrate
 them with twarc.py. For example:
 
     discover_ids.py '#code4lib' > ids.txt
-    twarc.py --hydrate ids.txt > tweets.json
+    twarc.py --hydrate ids.txt > tweets.jsonl
 
 """
 from __future__ import print_function

--- a/utils/extractor.py
+++ b/utils/extractor.py
@@ -38,10 +38,10 @@ class attriObject:
 def tweets_files(string, path):
     """Iterates over json files in path."""
     for filename in os.listdir(path):
-        if re.match(string, filename) and ".json" in filename:
+        if re.match(string, filename) and ".jsonl" in filename:
             f = gzip.open if ".gz" in filename else open
             yield path + filename, f
-            
+
             Ellipsis
 
 def parse(args):
@@ -105,10 +105,10 @@ def extract(json_object, args, csv_writer):
                 for row in new:
                     row.append(value)
                 found1.extend(new)
-            found = found1    
+            found = found1
 
     for row in found:
-        
+
         csv_writer.writerow(row)
     return len(found)
 
@@ -132,5 +132,5 @@ if __name__ == "__main__":
     args.attributes = [attriObject(i) for i in args.attributes]
     args.string = re.compile(args.string)
     args.hashtag = args.hashtag.lower()
-    
+
     parse(args)

--- a/utils/filter_date.py
+++ b/utils/filter_date.py
@@ -6,7 +6,7 @@ For example, if a hashtag was used for another event before the one you're
 interested in, you can filter out the old ones.
 
 Example usage:
-utils\filter_date.py --mindate 1-may-2014 tweets.json > filtered.json
+utils\filter_date.py --mindate 1-may-2014 tweets.jsonl > filtered.jsonl
 """
 from __future__ import print_function
 
@@ -26,7 +26,7 @@ if len(sys.argv) > 1:
         del sys.argv[0]
         del sys.argv[0]
 
-# fh = open('date_filtered.json', 'w')
+# fh = open('date_filtered.jsonl', 'w')
 # kept, discarded = 0, 0
 
 for line in fileinput.input():

--- a/utils/image_urls.py
+++ b/utils/image_urls.py
@@ -4,7 +4,7 @@
 Print out the URLs of images uploaded to Twitter in a tweet json stream.
 Useful for piping to wget or curl to mass download. In Bash:
 
-% wget $(./utils/image_urls.py tweets.json)
+% wget $(./utils/image_urls.py tweets.jsonl)
 """
 from __future__ import print_function
 

--- a/utils/network.py
+++ b/utils/network.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
 
-# build a reply, quote, retweet network from a file of tweets and write it 
-# out as a gexf, dot, json or  html file. You will need to have networkx 
-# installed and pydotplus if you want to use dot. The html presentation 
+# build a reply, quote, retweet network from a file of tweets and write it
+# out as a gexf, dot, json or  html file. You will need to have networkx
+# installed and pydotplus if you want to use dot. The html presentation
 # uses d3 to display the network graph in your browser.
-# 
-#   ./network.py tweets.json network.html
 #
-# or 
-#   ./network.py tweets.json network.dot
+#   ./network.py tweets.jsonl network.html
 #
 # or
-# 
-#  ./network.py tweets.json network.gexf
+#   ./network.py tweets.jsonl network.dot
+#
+# or
+#
+#  ./network.py tweets.jsonl network.gexf
 #
 # if you would rather have the network oriented around nodes that are users
 # instead of tweets use the --users flag
 #
-#  ./network.py --users tweets.json network.gexf
+#  ./network.py --users tweets.jsonl network.gexf
 #
 # TODO: this is mostly here some someone can improve it :)
 
@@ -29,20 +29,20 @@ import optparse
 from networkx import nx_pydot
 from networkx.readwrite import json_graph
 
-usage = "network.py tweets.json graph.html"
+usage = "network.py tweets.jsonl graph.html"
 opt_parser = optparse.OptionParser(usage=usage)
 
 opt_parser.add_option(
-    "--retweets", 
-    dest="retweets", 
+    "--retweets",
+    dest="retweets",
     action="store_true",
     help="include retweets"
 )
 
 opt_parser.add_option(
-    "--min_subgraph_size", 
-    dest="min_subgraph_size", 
-    type="int", 
+    "--min_subgraph_size",
+    dest="min_subgraph_size",
+    type="int",
     help="remove any subgraphs with a size smaller than this number"
 )
 
@@ -106,7 +106,7 @@ for line in open(tweets):
         t = json.loads(line)
     except:
         continue
-    from_id = t['id_str'] 
+    from_id = t['id_str']
     from_user = t['user']['screen_name']
     from_user_id = t['user']['id_str']
     to_user = None

--- a/utils/noretweets.py
+++ b/utils/noretweets.py
@@ -3,7 +3,7 @@
 Given a JSON file, remove any retweets.
 
 Example usage:
-utils/noretweets.py tweets.json > tweets_noretweets.json
+utils/noretweets.py tweets.jsonl > tweets_noretweets.jsonl
 """
 from __future__ import print_function
 import json

--- a/utils/remove_limit.py
+++ b/utils/remove_limit.py
@@ -9,7 +9,7 @@ If --warnings was used, you will have the following in output:
 This utility removes any limit warnings from output.
 
 Usage:
-    remove_limit.py aleppo.json > aleppo_no_warnings.json
+    remove_limit.py aleppo.jsonl > aleppo_no_warnings.jsonl
 """
 
 from __future__ import print_function

--- a/utils/sort_by_id.py
+++ b/utils/sort_by_id.py
@@ -9,7 +9,7 @@ The output of `twarc --scrape` isn't necessarily in strict (reverse)
 chronological order.
 
 Example usage:
-utils/sort_by_id.py tweets.json > sorted.json
+utils/sort_by_id.py tweets.jsonl > sorted.jsonl
 """
 from __future__ import print_function
 

--- a/utils/source.py
+++ b/utils/source.py
@@ -3,7 +3,7 @@
 Util to count which clients are most used.
 
 Example usage:
-utils/source.py tweets.json > sources.html
+utils/source.py tweets.jsonl > sources.html
 """
 from __future__ import print_function
 import json

--- a/utils/twarc-archive.py
+++ b/utils/twarc-archive.py
@@ -13,16 +13,16 @@ run it:
 The first time you run this it will search twitter for tweets matching
 "ferguson" and write them to a file:
 
-    /mnt/tweets/ferguson/tweets-0001.json
+    /mnt/tweets/ferguson/tweets-0001.jsonl
 
 When you run the exact same command again:
 
     % twarc-archive.py ferguson /mnt/tweets/ferguson
 
-it will get the first tweet id in tweets-0001.json and use it to write another
+it will get the first tweet id in tweets-0001.jsonl and use it to write another
 file which includes any new tweets since that tweet:
 
-    /mnt/tweets/ferguson/tweets-0002.json
+    /mnt/tweets/ferguson/tweets-0002.jsonl
 
 This functionality was initially part of twarc.py itself, but has been split out
 into a separate utility.
@@ -38,8 +38,8 @@ import twarc
 import logging
 import argparse
 
-archive_file_fmt = "tweets-%04i.json"
-archive_file_pat = "tweets-(\d{4}).json$"
+archive_file_fmt = "tweets-%04i.jsonl"
+archive_file_pat = "tweets-(\d{4}).jsonl$"
 
 def main():
     config = os.path.join(os.path.expanduser("~"), ".twarc")

--- a/utils/wall.py
+++ b/utils/wall.py
@@ -5,7 +5,7 @@
 Feed wall.py your JSON and get a wall of tweets as HTML. If you want to get the
 wall in chronological order, a handy trick is:
 
-    % tail -r tweets.json | ./wall.py > wall.html
+    % tail -r tweets.jsonl | ./wall.py > wall.html
 
 """
 from __future__ import print_function


### PR DESCRIPTION
Fixes #173 to make it clear twarc deals in line-oriented JSON rather than pure JSON.

Changed READMEs and utils.

Should either of these be changed or added to?

* https://github.com/DocNow/twarc/blob/master/utils/network.py#L156
* https://github.com/DocNow/twarc/blob/master/utils/extractor.py#L41