### PR TITLE
Fix missing datetime import in command.py and missing timeouts for requests

### DIFF
--- a/twarc/client.py
+++ b/twarc/client.py
@@ -534,7 +534,8 @@ class Twarc(object):
         connection_error_count = kwargs.pop('connection_error_count', 0)
         try:
             logging.info("getting %s %s", args, kwargs)
-            r = self.last_response = self.client.get(*args, **kwargs)
+            r = self.last_response = self.client.get(*args, timeout=(3.05, 31),
+                                                     **kwargs)
             # this has been noticed, believe it or not
             # https://github.com/edsu/twarc/issues/75
             if r.status_code == 404 and not allow_404:
@@ -570,7 +571,8 @@ class Twarc(object):
         connection_error_count = kwargs.pop('connection_error_count', 0)
         try:
             logging.info("posting %s %s", args, kwargs)
-            self.last_response = self.client.post(*args, **kwargs)
+            self.last_response = self.client.post(*args, timeout=(3.05, 31),
+                                                  **kwargs)
             return self.last_response
         except requests.exceptions.ConnectionError as e:
             connection_error_count += 1

--- a/twarc/command.py
+++ b/twarc/command.py
@@ -6,6 +6,7 @@ import sys
 import json
 import codecs
 import logging
+import datetime
 import argparse
 import fileinput
 


### PR DESCRIPTION
Regarding the second commit: If no timeout is specified, twarc may hang indefinitely if the internet connection is dropped but the requests connections is not closed (which does not necessarily happen, or at least not in a reasonably short timeframe). Now twarc will continue its work after the timeout.

> The default timeout is "infinite". However following the twitter streaming data
> API documentation we need to timeout: "Your app has received zero data through
> the connection – i.e. no new Tweets AND no keep-alive carriage return signals –
> for more than 30 seconds. Your app must allow the connection to time out in this
> situation" (https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data#reconnecting)
> 
> After a read timeout twarc will try to reconnect until the connection succeeds
> or connection_error_count is exceede. As the reconnect is implemented
> recursively that may raise "maximum recursion depth exceeded" errors that are
> themselve caught and the connection attempts will restart.