### PR TITLE
Fixes json2csv UnicodeEncodeError

### DIFF
--- a/twarc/json2csv.py
+++ b/twarc/json2csv.py
@@ -58,7 +58,7 @@ def get_headings():
 def get_row(t):
     get = t.get
     user = t.get('user').get
-    return [
+    return [v.encode('utf-8') if isinstance(v, str) else v for v in [
       get('id_str'),
       tweet_url(t),
       get('created_at'),
@@ -96,7 +96,7 @@ def get_row(t):
       user('time_zone'),
       user_urls(t),
       user('verified'),
-    ]
+    ]]
 
 
 def text(t):


### PR DESCRIPTION
Steps to reproduce:
On Ubuntu 16.04 with Python 3.6.3: `python utils/json2csv.py error.json`

Result:
```
id,tweet_url,created_at,parsed_created_at,user_screen_name,text,tweet_type,coordinates,hashtags,media,urls,favorite_count,in_reply_to_screen_name,in_reply_to_status_id,in_reply_to_user_id,lang,place,possibly_sensitive,retweet_count,reweet_or_quote_id,retweet_or_quote_screen_name,retweet_or_quote_user_id,source,user_id,user_created_at,user_default_profile_image,user_description,user_favourites_count,user_followers_count,user_friends_count,user_listed_count,user_location,user_name,user_statuses_count,user_time_zone,user_urls,user_verified
Traceback (most recent call last):
  File "utils/json2csv.py", line 101, in <module>
    main()
  File "utils/json2csv.py", line 67, in main
    sheet.writerow(get_row(tweet, extra_fields=extra_fields))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 516-517: ordinal not in range(128)
```

I can't reproduce this locally on my Mac.
[error.json.txt](https://github.com/DocNow/twarc/files/1693236/error.json.txt)
