### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
         author_email='ehs@pobox.com',
         packages=['twarc',],
         description='Archive tweets from the command line',
+        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         install_requires=dependencies,
         setup_requires=['pytest-runner'],
         tests_require=['pytest'],


### PR DESCRIPTION
When old Python versions are dropped, this will help pip install the right version for people still running those old Python versions.
 
For more info on how this works:
* https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4
* https://github.com/pypa/python-packaging-user-guide/issues/450