### PR TITLE
Show README.md on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools import setup
 # Also in twarc.py
 __version__ = '1.4.5'
 
+with open("README.md") as f:
+    long_description = f.read()
+
 if sys.version_info[0] < 3:
     dependencies = open(join('requirements', 'python2.txt')).read().split()
 else:
@@ -21,6 +24,8 @@ if __name__ == "__main__":
         author_email='ehs@pobox.com',
         packages=['twarc',],
         description='Archive tweets from the command line',
+        long_description=long_description,
+        long_description_content_type="text/markdown",
         python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         install_requires=dependencies,
         setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import sys
-import os
 
 from os.path import join
 from setuptools import setup
@@ -22,7 +21,7 @@ if __name__ == "__main__":
         url='https://github.com/docnow/twarc',
         author='Ed Summers',
         author_email='ehs@pobox.com',
-        packages=['twarc',],
+        packages=['twarc', ],
         description='Archive tweets from the command line',
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
Now the new PyPI (Warehouse) has launched, Markdown is finally supported as the long description for https://pypi.org/project/twarc/.

So instead of https://pypi.org/project/twarc/ showing:

![image](https://user-images.githubusercontent.com/1324225/40113630-c890c4aa-5912-11e8-8863-3ee5356494da.png)

you can have the README.md in there.

Make sure these tools are up-to-date:

```bash
pip install -U setuptools twine wheel
```

For more info:
* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example