### PR TITLE
Stream in and out noretweets.

### DIFF
--- a/utils/noretweets.py
+++ b/utils/noretweets.py
@@ -8,17 +8,9 @@ utils/noretweets.py tweets.jsonl > tweets_noretweets.jsonl
 from __future__ import print_function
 import json
 import fileinput
-from collections import OrderedDict
 
-seen = OrderedDict()
 for line in fileinput.input():
     tweet = json.loads(line)
 
     if not 'retweeted_status' in tweet:
-        id = tweet['id']
-        seen[id] = tweet
-
-for tweet in seen.values():
-    print(json.dumps(tweet))
-
-# End of file
+        print(json.dumps(tweet))


### PR DESCRIPTION
Previous method held everything in memory, which makes working with large datasets difficult. This method should just stream them in and out.