### PR TITLE
Fix to string cleaning in json2csv for python 2.

### DIFF
--- a/twarc/json2csv.py
+++ b/twarc/json2csv.py
@@ -3,6 +3,7 @@
 import sys
 
 from dateutil.parser import parse as date_parse
+from six import string_types
 
 if sys.version_info[0] < 3:
     try:
@@ -100,7 +101,7 @@ def get_row(t, excel=False):
 
 
 def clean_str(string):
-    if isinstance(string, str):
+    if isinstance(string, string_types):
         return string.replace('\n', ' ').replace('\r', '')
     return None
 


### PR DESCRIPTION
See https://github.com/gwu-libraries/sfm-ui/issues/935.

Steps to reproduce:
python2 utils/json2csv.py -x some_tweets.jsonl

Expected result:
Text field is populated with text of the tweet.

Actual result:
Text field is blank.