### PR TITLE
Bugfix for numeric user_id passed to timeline

### DIFF
--- a/test_twarc.py
+++ b/test_twarc.py
@@ -210,6 +210,21 @@ def test_timeline_by_screen_name():
     for tweet in T.timeline(screen_name=screen_name):
         assert tweet['user']['screen_name'].lower() == screen_name.lower()
 
+
+def test_timeline_arg_handling():
+    # Confirm that only user_id *or* screen_name is valid for timeline
+    screen_name = "guardian"
+    user_id = "87818409"
+
+    with pytest.raises(ValueError):
+        for t in T.timeline(screen_name=None, user_id=None):
+            pass
+
+    with pytest.raises(ValueError):
+        for t in T.timeline(screen_name=screen_name, user_id=user_id):
+            pass
+
+
 def test_timeline_with_since_id():
     count = 0
     tweet_id = None

--- a/test_twarc.py
+++ b/test_twarc.py
@@ -193,6 +193,15 @@ def test_timeline_by_user_id():
     for tweet in T.timeline(user_id=user_id):
         assert tweet['user']['id_str'] == user_id
 
+    # Make sure that passing an int user_id behaves as expected. Issue #235
+    user_id = 87818409
+
+    all_tweets = list(T.timeline(user_id=user_id))
+    assert len(all_tweets)
+
+    for tweet in all_tweets:
+        assert tweet['user']['id'] == user_id
+
 
 def test_timeline_by_screen_name():
     # looks for recent tweets and checks if tweets are of provided screen_name

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -111,6 +111,12 @@ class Twarc(object):
         by the user indicated by the user_id or screen_name parameter.
         Provide a user_id or screen_name.
         """
+
+        if user_id and screen_name:
+            raise ValueError('only user_id or screen_name may be passed')
+        elif not (user_id or screen_name):
+            raise ValueError('one of user_id or screen_name must be passed')
+
         # Strip if screen_name is prefixed with '@'
         if screen_name:
             screen_name = screen_name.lstrip('@')

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -114,7 +114,7 @@ class Twarc(object):
         # Strip if screen_name is prefixed with '@'
         if screen_name:
             screen_name = screen_name.lstrip('@')
-        id = screen_name or user_id
+        id = screen_name or str(user_id)
         id_type = "screen_name" if screen_name else "user_id"
         logging.info("starting user timeline for user %s", id)
         url = "https://api.twitter.com/1.1/statuses/user_timeline.json"
@@ -143,8 +143,8 @@ class Twarc(object):
             for status in statuses:
                 # If you request an invalid user_id, you may still get
                 # results so need to check.
-                if not user_id or user_id == status.get("user",
-                                                        {}).get("id_str"):
+                if not user_id or id == status.get("user",
+                                                   {}).get("id_str"):
                     yield status
 
             max_id = str(int(status["id_str"]) - 1)


### PR DESCRIPTION
This is the minimal fix, I couldn't find anywhere else this pattern is used so I just took the approach of always converting the user_id to a string for the checks. Hopefully this will make it less surprising for others.

Fixes #235 