### PR TITLE
Pagination enhancement and optimisation

### DIFF
--- a/test_twarc.py
+++ b/test_twarc.py
@@ -45,7 +45,9 @@ def test_search():
 
 def test_search_max_pages():
     tweets = list(T.search('obama', max_pages=1))
-    assert len(tweets) == 100
+    assert 0 < len(tweets) <= 100
+    tweets = list(T.search('obama', max_pages=2))
+    assert 100 < len(tweets) <= 200
 
 
 def test_since_id():
@@ -214,6 +216,9 @@ def test_timeline_max_pages():
 
     first_page = list(T.timeline(user_id=user_id, max_pages=1))
     assert 0 < len(first_page) <= 200
+
+    all_pages = list(T.timeline(user_id=user_id))
+    assert len(all_pages) > len(first_page)
 
 
 def test_timeline_by_screen_name():

--- a/test_twarc.py
+++ b/test_twarc.py
@@ -43,6 +43,11 @@ def test_search():
     assert count == 10
 
 
+def test_search_max_pages():
+    tweets = list(T.search('obama', max_pages=1))
+    assert len(tweets) == 100
+
+
 def test_since_id():
     for tweet in T.search('obama'):
         id = tweet['id_str']
@@ -201,6 +206,14 @@ def test_timeline_by_user_id():
 
     for tweet in all_tweets:
         assert tweet['user']['id'] == user_id
+
+
+def test_timeline_max_pages():
+    # looks for recent tweets and checks if tweets are of provided user_id
+    user_id = "87818409"
+
+    first_page = list(T.timeline(user_id=user_id, max_pages=1))
+    assert 0 < len(first_page) <= 200
 
 
 def test_timeline_by_screen_name():

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -66,7 +66,7 @@ class Twarc(object):
 
     @filter_protected
     def search(self, q, max_id=None, since_id=None, lang=None,
-               result_type='recent', geocode=None):
+               result_type='recent', geocode=None, max_pages=None):
         """
         Pass in a query with optional max_id, min_id, lang or geocode
         and get back an iterator for decoded tweets. Defaults to recent (i.e.
@@ -87,13 +87,20 @@ class Twarc(object):
         if geocode is not None:
             params['geocode'] = geocode
 
+        retrieved_pages = 0
+        reached_end = False
+
         while True:
             if since_id:
-                params['since_id'] = since_id
+                # Make the since_id inclusive, so we can avoid retrieving
+                # an empty page of results in some cases
+                params['since_id'] = str(int(since_id) - 1)
             if max_id:
                 params['max_id'] = max_id
 
             resp = self.get(url, params=params)
+            retrieved_pages += 1
+
             statuses = resp.json()["statuses"]
 
             if len(statuses) == 0:
@@ -101,12 +108,25 @@ class Twarc(object):
                 break
 
             for status in statuses:
+                # We've certainly reached the end of new results
+                if status['id_str'] == str(since_id):
+                    reached_end = True
+                    break
+
                 yield status
+
+            if reached_end:
+                logging.info("no new tweets matching %s", params)
+                break
+
+            if max_pages is not None and retrieved_pages == max_pages:
+                logging.info("reached max page limit for %s", params)
+                break
 
             max_id = str(int(status["id_str"]) - 1)
 
     def timeline(self, user_id=None, screen_name=None, max_id=None,
-                 since_id=None):
+                 since_id=None, max_pages=None):
         """
         Returns a collection of the most recent tweets posted
         by the user indicated by the user_id or screen_name parameter.
@@ -127,14 +147,20 @@ class Twarc(object):
         url = "https://api.twitter.com/1.1/statuses/user_timeline.json"
         params = {"count": 200, id_type: id, "include_ext_alt_text": "true"}
 
+        retrieved_pages = 0
+        reached_end = False
+
         while True:
             if since_id:
-                params['since_id'] = since_id
+                # Make the since_id inclusive, so we can avoid retrieving
+                # an empty page of results in some cases
+                params['since_id'] = str(int(since_id) - 1)
             if max_id:
                 params['max_id'] = max_id
 
             try:
                 resp = self.get(url, params=params, allow_404=True)
+                retrieved_pages += 1
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
                     logging.info("no timeline available for %s", id)
@@ -148,11 +174,23 @@ class Twarc(object):
                 break
 
             for status in statuses:
+                # We've certainly reached the end of new results
+                if status['id_str'] == str(since_id):
+                    reached_end = True
+                    break
                 # If you request an invalid user_id, you may still get
                 # results so need to check.
                 if not user_id or id == status.get("user",
                                                    {}).get("id_str"):
                     yield status
+
+            if reached_end:
+                logging.info("no new tweets matching %s", params)
+                break
+
+            if max_pages is not None and retrieved_pages == max_pages:
+                logging.info("reached max page limit for %s", params)
+                break
 
             max_id = str(int(status["id_str"]) - 1)
 

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -109,7 +109,7 @@ class Twarc(object):
 
             for status in statuses:
                 # We've certainly reached the end of new results
-                if status['id_str'] == str(since_id):
+                if since_id is not None and status['id_str'] == str(since_id):
                     reached_end = True
                     break
 
@@ -175,7 +175,7 @@ class Twarc(object):
 
             for status in statuses:
                 # We've certainly reached the end of new results
-                if status['id_str'] == str(since_id):
+                if since_id is not None and status['id_str'] == str(since_id):
                     reached_end = True
                     break
                 # If you request an invalid user_id, you may still get


### PR DESCRIPTION
Background: I have a use case that requires polling a lot of not very active timelines, and for this case the need to retrieve an empty page of results to indicate the end of pagination, and the need to page through the entire set of results can have a big impact on throughput.

This PR adds to `Twarc.timeline` and `Twarc.search`:
- An optimisation around since_id handling that in the happy path lets us skip an API call that would not return any more results - this change should be transparent to the user, it just means less API calls are made. This works by making the since_id in the call inclusive, and using the tweet with that since_id as a sentinel for the end of pagination.
- A (default off) argument max_pages that limits the number of pages retrieved instead of retrieving everything.