### PR TITLE
Update README.md to include installation of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ generate an access token and access token secret. With these four variables
 in hand you are ready to start using twarc.
 
 1. install [Python](http://python.org/download) (2 or 3)
-2. pip install twarc (if upgrading: pip install --upgrade twarc)
+2. sudo easy_install pip
+3. pip install twarc (if upgrading: pip install --upgrade twarc)
 
 ## Quickstart:
 


### PR DESCRIPTION
In the process of directing someone who had little experience using the terminal, I realized this was also required (at least on OSX).  So I figured, as long as we're starting the instructions at the installation of python itself, the installation of pip might be a good addition.