### PR TITLE
Catch and display better errors on authentication failures (401)

### DIFF
--- a/test_twarc.py
+++ b/test_twarc.py
@@ -539,3 +539,17 @@ def test_extended_compat():
 
     assert 'full_text' in next(T.timeline(screen_name="BarackObama"))
     assert 'text' in next(t_compat.timeline(screen_name="BarackObama"))
+
+
+def test_invalid_credentials():
+    old_consumer_key = T.consumer_key
+    T.consumer_key = None
+
+    with pytest.raises(RuntimeError):
+        T.validate_keys()
+
+    T.consumer_key = 'Definitely not a valid key'
+    with pytest.raises(RuntimeError):
+        T.validate_keys()
+
+    T.consumer_key = old_consumer_key

--- a/test_twarc.py
+++ b/test_twarc.py
@@ -432,7 +432,9 @@ def test_connection_error_get(oauth1session_class):
     mock_oauth1session = MagicMock(spec=OAuth1Session)
     oauth1session_class.return_value = mock_oauth1session
     mock_oauth1session.get.side_effect = requests.exceptions.ConnectionError
-    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", connection_errors=3)
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token",
+                    "access_token_secret", connection_errors=3,
+                    validate_keys=False)
     with pytest.raises(requests.exceptions.ConnectionError):
         t.get("https://api.twitter.com")
 
@@ -444,7 +446,9 @@ def test_connection_error_post(oauth1session_class):
     mock_oauth1session = MagicMock(spec=OAuth1Session)
     oauth1session_class.return_value = mock_oauth1session
     mock_oauth1session.post.side_effect = requests.exceptions.ConnectionError
-    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", connection_errors=2)
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token",
+                    "access_token_secret", connection_errors=2,
+                    validate_keys=False)
     with pytest.raises(requests.exceptions.ConnectionError):
         t.post("https://api.twitter.com")
 
@@ -452,19 +456,22 @@ def test_connection_error_post(oauth1session_class):
 
 
 def test_http_error_sample():
-    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", http_errors=2)
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token",
+                    "access_token_secret", http_errors=2, validate_keys=False)
     with pytest.raises(requests.exceptions.HTTPError):
         next(t.sample())
 
 
 def test_http_error_filter():
-    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", http_errors=3)
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token",
+                    "access_token_secret", http_errors=3, validate_keys=False)
     with pytest.raises(requests.exceptions.HTTPError):
         next(t.filter(track="test"))
 
 
 def test_http_error_timeline():
-    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", http_errors=4)
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token",
+                    "access_token_secret", http_errors=4, validate_keys=False)
     with pytest.raises(requests.exceptions.HTTPError):
         next(t.timeline(user_id="test"))
 

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -63,6 +63,7 @@ class Twarc(object):
             self.config = self.default_config()
 
         self.get_keys()
+        self.validate_keys()
 
     @filter_protected
     def search(self, q, max_id=None, since_id=None, lang=None,
@@ -707,6 +708,9 @@ class Twarc(object):
 
         if keys_present:
             try:
+                # Need to explicitly reconnect to confirm the current creds
+                # are used in the session object.
+                self.connect()
                 self.get(url)
             except requests.HTTPError as e:
                 if e.response.status_code == 401:

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -37,7 +37,8 @@ class Twarc(object):
     def __init__(self, consumer_key=None, consumer_secret=None,
                  access_token=None, access_token_secret=None,
                  connection_errors=0, http_errors=0, config=None,
-                 profile="", protected=False, tweet_mode="extended"):
+                 profile="", protected=False, tweet_mode="extended",
+                 validate_keys=True):
         """
         Instantiate a Twarc instance. If keys aren't set we'll try to
         discover them in the environment or a supplied profile. If no
@@ -63,7 +64,9 @@ class Twarc(object):
             self.config = self.default_config()
 
         self.get_keys()
-        self.validate_keys()
+
+        if validate_keys:
+            self.validate_keys()
 
     @filter_protected
     def search(self, q, max_id=None, since_id=None, lang=None,


### PR DESCRIPTION
Based on the discussion in #227:

1. Catches and raises an error with a more specific message when a method hits an authentication failure (HTTP 401), such as for protected accounts or invalid credentials. 
2. To better handle the issue of invalid credentials from the beginning, adds key validation that explicitly checks against the Twitter API on client initialisation. This makes it easier to flag when the credentials are invalid and explicitly notify the user.

One issue I want to flag is that key validation is currently on by default, but that endpoint only allows 75 requests/15 minutes. I'm not really sure how people are making use of the CLI, so that might be a little restrictive with lots of invocations.