### PR TITLE
Add tweet_urls.py

### DIFF
--- a/utils/tweet_urls.py
+++ b/utils/tweet_urls.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+"""
+Used in conjunction with retweet.py.
+
+Prints out the retweet count, and url of the retweeted tweet.
+
+Takes in the output from retweet.py
+
+tweet_urls.py retweets.jsonl > retweets.txt
+"""
+from __future__ import print_function
+
+import sys
+import json
+import fileinput
+
+for line in fileinput.input():
+    try:
+        tweet = json.loads(line)
+        tweet_id = tweet["id_str"]
+        screen_name = tweet["user"]["screen_name"]
+        retweet_count = tweet["retweet_count"]
+        tweet_urls = "https://twitter.com/%s/status/%s" % (screen_name,tweet_id)
+        print ("%d retweets of %s" % (retweet_count, tweet_urls))
+    except Exception as e:
+        sys.stderr.write("uhoh: %s\n" % e)


### PR DESCRIPTION
Mentioned a bit about this in Slack.

Looks like this is a script I created for the [Code4Lib article on the #elxn42 analysis](https://journal.code4lib.org/articles/11358), and mentioned [here](https://ruebot.net/2015/12/a-look-at-14939154-paris-bataclan-parisattacks-porteouverte-tweets/) too for the Bataclan analysis.

It should probably be here, but I'll admit is a niche utility, and might be named a little misleadingly in retrospect a few years later.

cc: @thomasgpadilla