### PR TITLE
Update tags.py example to work with Python3.

### DIFF
--- a/utils/tags.py
+++ b/utils/tags.py
@@ -3,20 +3,14 @@ from __future__ import print_function
 
 import json
 import fileinput
+import collections
 
-counts = {}
+counts = collections.Counter()
 for line in fileinput.input():
-    try:
-        tweet = json.loads(line)
-    except:
-        continue
-
+    tweet = json.loads(line)
     for tag in tweet['entities']['hashtags']:
         t = tag['text'].lower()
-        counts[t] = counts.get(t, 0) + 1
+        counts[t] += 1
 
-tags = counts.keys()
-tags.sort(lambda a, b: cmp(counts[b], counts[a]))
-
-for tag in tags:
-    print(tag.encode('utf8'), counts[tag])
+for tag, count in counts.most_common():
+    print("%5i %s" % (count, tag))


### PR DESCRIPTION
The tags.py example does not work with Python3 due to the changed dict interface (`dict.keys()` has no method `.sort()`).

I rewrote the example to follow the emoji example and use `collections.Counter()`.