### PR TITLE
Changed network graph output to directed graphs

### DIFF
--- a/utils/network.py
+++ b/utils/network.py
@@ -67,7 +67,7 @@ if len(args) != 2:
 
 tweets, output = args
 
-G = networkx.Graph()
+G = networkx.DiGraph()
 
 def add(from_user, from_id, to_user, to_id, type):
     "adds a relation to the graph"


### PR DESCRIPTION
Since Twitter allows for one directional follows, and retweets and replies are inherently directional, a directed graph is preferable to an undirected graph. This change simply changes the default to directed. Next an option will be added to select undirected or directed.