### PR TITLE
Moves to using a named logger.

### DIFF
--- a/twarc/client.py
+++ b/twarc/client.py
@@ -29,6 +29,8 @@ else:
     import configparser
     from urllib.parse import parse_qs
 
+log = logging.getLogger('twarc')
+
 
 class Twarc(object):
     """
@@ -112,7 +114,7 @@ class Twarc(object):
             statuses = resp.json()["statuses"]
 
             if len(statuses) == 0:
-                logging.info("no new tweets matching %s", params)
+                log.info("no new tweets matching %s", params)
                 break
 
             for status in statuses:
@@ -124,11 +126,11 @@ class Twarc(object):
                 yield status
 
             if reached_end:
-                logging.info("no new tweets matching %s", params)
+                log.info("no new tweets matching %s", params)
                 break
 
             if max_pages is not None and retrieved_pages == max_pages:
-                logging.info("reached max page limit for %s", params)
+                log.info("reached max page limit for %s", params)
                 break
 
             max_id = str(int(status["id_str"]) - 1)
@@ -149,7 +151,7 @@ class Twarc(object):
             screen_name = screen_name.lstrip('@')
         id = screen_name or str(user_id)
         id_type = "screen_name" if screen_name else "user_id"
-        logging.info("starting user timeline for user %s", id)
+        log.info("starting user timeline for user %s", id)
 
         if screen_name or user_id:
             url = "https://api.twitter.com/1.1/statuses/user_timeline.json"
@@ -174,14 +176,14 @@ class Twarc(object):
                 retrieved_pages += 1
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
-                    logging.info("no timeline available for %s", id)
+                    log.info("no timeline available for %s", id)
                     break
                 raise e
 
             statuses = resp.json()
 
             if len(statuses) == 0:
-                logging.info("no new tweets matching %s", params)
+                log.info("no new tweets matching %s", params)
                 break
 
             for status in statuses:
@@ -196,11 +198,11 @@ class Twarc(object):
                     yield status
 
             if reached_end:
-                logging.info("no new tweets matching %s", params)
+                log.info("no new tweets matching %s", params)
                 break
 
             if max_pages is not None and retrieved_pages == max_pages:
-                logging.info("reached max page limit for %s", params)
+                log.info("reached max page limit for %s", params)
                 break
 
             max_id = str(int(status["id_str"]) - 1)
@@ -224,14 +226,14 @@ class Twarc(object):
 
         def do_lookup():
             ids_str = ",".join(lookup_ids)
-            logging.info("looking up users %s", ids_str)
+            log.info("looking up users %s", ids_str)
             url = 'https://api.twitter.com/1.1/users/lookup.json'
             params = {id_type: ids_str}
             try:
                 resp = self.get(url, params=params, allow_404=True)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
-                    logging.warn("no users matching %s", ids_str)
+                    log.warning("no users matching %s", ids_str)
                 raise e
             return resp.json()
 
@@ -265,7 +267,7 @@ class Twarc(object):
                 resp = self.get(url, params=params, allow_404=True)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
-                    logging.info("no users matching %s", screen_name)
+                    log.info("no users matching %s", screen_name)
                 raise e
             user_ids = resp.json()
             for user_id in user_ids['ids']:
@@ -291,7 +293,7 @@ class Twarc(object):
                 resp = self.get(url, params=params, allow_404=True)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
-                    logging.error("no users matching %s", user)
+                    log.error("no users matching %s", user)
                 raise e
 
             user_ids = resp.json()
@@ -329,47 +331,47 @@ class Twarc(object):
         errors = 0
         while True:
             try:
-                logging.info("connecting to filter stream for %s", params)
+                log.info("connecting to filter stream for %s", params)
                 resp = self.post(url, params, headers=headers, stream=True)
                 errors = 0
                 for line in resp.iter_lines(chunk_size=1024):
                     if event and event.is_set():
-                        logging.info("stopping filter")
+                        log.info("stopping filter")
                         # Explicitly close response
                         resp.close()
                         return
                     if not line:
-                        logging.info("keep-alive")
+                        log.info("keep-alive")
                         if record_keepalive:
                             yield "keep-alive"
                         continue
                     try:
                         yield json.loads(line.decode())
                     except Exception as e:
-                        logging.error("json parse error: %s - %s", e, line)
+                        log.error("json parse error: %s - %s", e, line)
             except requests.exceptions.HTTPError as e:
                 errors += 1
-                logging.error("caught http error %s on %s try", e, errors)
+                log.error("caught http error %s on %s try", e, errors)
                 if self.http_errors and errors == self.http_errors:
-                    logging.warn("too many errors")
+                    log.warning("too many errors")
                     raise e
                 if e.response.status_code == 420:
                     if interruptible_sleep(errors * 60, event):
-                        logging.info("stopping filter")
+                        log.info("stopping filter")
                         return
                 else:
                     if interruptible_sleep(errors * 5, event):
-                        logging.info("stopping filter")
+                        log.info("stopping filter")
                         return
             except Exception as e:
                 errors += 1
-                logging.error("caught exception %s on %s try", e, errors)
+                log.error("caught exception %s on %s try", e, errors)
                 if self.http_errors and errors == self.http_errors:
-                    logging.warn("too many exceptions")
+                    log.warning("too many exceptions")
                     raise e
-                logging.error(e)
+                log.error(e)
                 if interruptible_sleep(errors, event):
-                    logging.info("stopping filter")
+                    log.info("stopping filter")
                     return
 
     def sample(self, event=None, record_keepalive=False):
@@ -387,47 +389,47 @@ class Twarc(object):
         errors = 0
         while True:
             try:
-                logging.info("connecting to sample stream")
+                log.info("connecting to sample stream")
                 resp = self.post(url, params, headers=headers, stream=True)
                 errors = 0
                 for line in resp.iter_lines(chunk_size=512):
                     if event and event.is_set():
-                        logging.info("stopping sample")
+                        log.info("stopping sample")
                         # Explicitly close response
                         resp.close()
                         return
                     if line == "":
-                        logging.info("keep-alive")
+                        log.info("keep-alive")
                         if record_keepalive:
                             yield "keep-alive"
                         continue
                     try:
                         yield json.loads(line.decode())
                     except Exception as e:
-                        logging.error("json parse error: %s - %s", e, line)
+                        log.error("json parse error: %s - %s", e, line)
             except requests.exceptions.HTTPError as e:
                 errors += 1
-                logging.error("caught http error %s on %s try", e, errors)
+                log.error("caught http error %s on %s try", e, errors)
                 if self.http_errors and errors == self.http_errors:
-                    logging.warn("too many errors")
+                    log.warning("too many errors")
                     raise e
                 if e.response.status_code == 420:
                     if interruptible_sleep(errors * 60, event):
-                        logging.info("stopping filter")
+                        log.info("stopping filter")
                         return
                 else:
                     if interruptible_sleep(errors * 5, event):
-                        logging.info("stopping filter")
+                        log.info("stopping filter")
                         return
 
             except Exception as e:
                 errors += 1
-                logging.error("caught exception %s on %s try", e, errors)
+                log.error("caught exception %s on %s try", e, errors)
                 if self.http_errors and errors == self.http_errors:
-                    logging.warn("too many errors")
+                    log.warning("too many errors")
                     raise e
                 if interruptible_sleep(errors, event):
-                    logging.info("stopping filter")
+                    log.info("stopping filter")
                     return
 
     def dehydrate(self, iterator):
@@ -439,7 +441,7 @@ class Twarc(object):
             try:
                 yield json.loads(line)['id_str']
             except Exception as e:
-                logging.error("uhoh: %s\n" % e)
+                log.error("uhoh: %s\n" % e)
 
     def hydrate(self, iterator):
         """
@@ -455,7 +457,7 @@ class Twarc(object):
             tweet_id = tweet_id.strip()  # remove new line if present
             ids.append(tweet_id)
             if len(ids) == 100:
-                logging.info("hydrating %s ids", len(ids))
+                log.info("hydrating %s ids", len(ids))
                 resp = self.post(url, data={
                     "id": ','.join(ids),
                     "include_ext_alt_text": 'true'
@@ -468,7 +470,7 @@ class Twarc(object):
 
         # hydrate any remaining ones
         if len(ids) > 0:
-            logging.info("hydrating %s", ids)
+            log.info("hydrating %s", ids)
             resp = self.post(url, data={
                 "id": ','.join(ids),
                 "include_ext_alt_text": 'true'
@@ -487,7 +489,7 @@ class Twarc(object):
         Retrieves up to the last 100 retweets for the provided
         tweet.
         """
-        logging.info("retrieving retweets of %s", tweet_id)
+        log.info("retrieving retweets of %s", tweet_id)
         url = "https://api.twitter.com/1.1/statuses/retweets/""{}.json".format(
                 tweet_id)
 
@@ -520,7 +522,7 @@ class Twarc(object):
             resp = self.get(url, params=params, allow_404=True)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
-                logging.info("no region matching WOEID %s", woeid)
+                log.info("no region matching WOEID %s", woeid)
             raise e
         return resp.json()
 
@@ -552,17 +554,17 @@ class Twarc(object):
         # get replies to the tweet
         screen_name = tweet['user']['screen_name']
         tweet_id = tweet['id_str']
-        logging.info("looking for replies to: %s", tweet_id)
+        log.info("looking for replies to: %s", tweet_id)
         for reply in self.search("to:%s" % screen_name, since_id=tweet_id):
 
             if reply['in_reply_to_status_id_str'] != tweet_id:
                 continue
 
             if reply['id_str'] in prune:
-                logging.info("ignoring pruned tweet id %s", reply['id_str'])
+                log.info("ignoring pruned tweet id %s", reply['id_str'])
                 continue
 
-            logging.info("found reply: %s", reply["id_str"])
+            log.info("found reply: %s", reply["id_str"])
 
             if recursive:
                 if reply['id_str'] not in prune:
@@ -576,11 +578,11 @@ class Twarc(object):
         # get other potential replies to it
 
         reply_to_id = tweet.get('in_reply_to_status_id_str')
-        logging.info("prune=%s", prune)
+        log.info("prune=%s", prune)
         if recursive and reply_to_id and reply_to_id not in prune:
             t = self.tweet(reply_to_id)
             if t:
-                logging.info("found reply-to: %s", t['id_str'])
+                log.info("found reply-to: %s", t['id_str'])
                 prune = prune + (tweet['id_str'],)
                 for r in self.replies(t, recursive=True, prune=prune):
                     yield r
@@ -592,7 +594,7 @@ class Twarc(object):
         if recursive and quote_id and quote_id not in prune:
             t = self.tweet(quote_id)
             if t:
-                logging.info("found quote: %s", t['id_str'])
+                log.info("found quote: %s", t['id_str'])
                 prune = prune + (tweet['id_str'],)
                 for r in self.replies(t, recursive=True, prune=prune):
                     yield r
@@ -620,7 +622,7 @@ class Twarc(object):
                 resp = self.get(url, params=params, allow_404=True)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
-                    logging.error("no matching list")
+                    log.error("no matching list")
                 raise e
 
             users = resp.json()
@@ -645,23 +647,23 @@ class Twarc(object):
         allow_404 = kwargs.pop('allow_404', False)
         connection_error_count = kwargs.pop('connection_error_count', 0)
         try:
-            logging.info("getting %s %s", args, kwargs)
+            log.info("getting %s %s", args, kwargs)
             r = self.last_response = self.client.get(*args, timeout=(3.05, 31),
                                                      **kwargs)
             # this has been noticed, believe it or not
             # https://github.com/edsu/twarc/issues/75
             if r.status_code == 404 and not allow_404:
-                logging.warn("404 from Twitter API! trying again")
+                log.warning("404 from Twitter API! trying again")
                 time.sleep(1)
                 r = self.get(*args, **kwargs)
             return r
         except (ssl.SSLError, ConnectionError, ProtocolError) as e:
             connection_error_count += 1
-            logging.error("caught connection error %s on %s try", e,
+            log.error("caught connection error %s on %s try", e,
                           connection_error_count)
             if (self.connection_errors and
                     connection_error_count == self.connection_errors):
-                logging.error("received too many connection errors")
+                log.error("received too many connection errors")
                 raise e
             else:
                 self.connect()
@@ -682,17 +684,17 @@ class Twarc(object):
 
         connection_error_count = kwargs.pop('connection_error_count', 0)
         try:
-            logging.info("posting %s %s", args, kwargs)
+            log.info("posting %s %s", args, kwargs)
             self.last_response = self.client.post(*args, timeout=(3.05, 31),
                                                   **kwargs)
             return self.last_response
         except (ssl.SSLError, ConnectionError, ProtocolError) as e:
             connection_error_count += 1
-            logging.error("caught connection error %s on %s try", e,
+            log.error("caught connection error %s on %s try", e,
                           connection_error_count)
             if (self.connection_errors and
                     connection_error_count == self.connection_errors):
-                logging.error("received too many connection errors")
+                log.error("received too many connection errors")
                 raise e
             else:
                 self.connect()
@@ -709,12 +711,12 @@ class Twarc(object):
             raise RuntimeError("MissingKeys")
 
         if self.client:
-            logging.info("closing existing http session")
+            log.info("closing existing http session")
             self.client.close()
         if self.last_response:
-            logging.info("closing last response")
+            log.info("closing last response")
             self.last_response.close()
-        logging.info("creating http session")
+        log.info("creating http session")
 
         self.client = OAuth1Session(
             client_key=self.consumer_key,
@@ -771,7 +773,7 @@ class Twarc(object):
     def load_config(self):
         path = self.config
         profile = self.profile
-        logging.info("loading %s profile from config %s", profile, path)
+        log.info("loading %s profile from config %s", profile, path)
 
         if not path or not os.path.isfile(path):
             return {}

--- a/twarc/command.py
+++ b/twarc/command.py
@@ -28,6 +28,8 @@ else:
     str_type = str
     import configparser
 
+log = logging.getLogger('twarc')
+
 
 commands = [
     'configure',
@@ -254,7 +256,7 @@ def main():
         if kind_of == str_type:
             # user or tweet IDs
             print(thing, file=fh)
-            logging.info("archived %s" % thing)
+            log.info("archived %s" % thing)
         elif 'id_str' in thing:
             # tweets and users
             if (args.format == "json"):
@@ -263,7 +265,7 @@ def main():
                 csv_writer.writerow(get_row(thing))
             elif (args.format == "csv-excel"):
                 csv_writer.writerow(get_row(thing, excel=True))
-            logging.info("archived %s", thing['id_str'])
+            log.info("archived %s", thing['id_str'])
         elif 'woeid' in thing:
             # places
             print(json.dumps(thing), file=fh)
@@ -275,13 +277,13 @@ def main():
             t = datetime.datetime.utcfromtimestamp(
                 float(thing['limit']['timestamp_ms']) / 1000)
             t = t.isoformat("T") + "Z"
-            logging.warn("%s tweets undelivered at %s",
+            log.warning("%s tweets undelivered at %s",
                          thing['limit']['track'], t)
             if args.warnings:
                 print(json.dumps(thing), file=fh)
         elif 'warning' in thing:
             # other warnings
-            logging.warn(thing['warning']['message'])
+            log.warning(thing['warning']['message'])
             if args.warnings:
                 print(json.dumps(thing), file=fh)
 


### PR DESCRIPTION
Also, changed deprecated `.warn` to `.warning`.

This change can be tested by adding / removing `logging.getLogger("twarc").setLevel(logging.ERROR)` after basic config `logging.basicConfig` in `commands.py`.

closes #271 
