### PR TITLE
README: fix links to Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ twarc
 twarc is a command line tool and Python library for archiving Twitter JSON data.
 Each tweet is represented as a JSON object that is
 [exactly](https://dev.twitter.com/overview/api/tweets) what was returned from
-the Twitter API.  Tweets are stored as [line-oriented JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON).  Twarc will handle
+the Twitter API.  Tweets are stored as [line-oriented JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line-delimited_JSON).  Twarc will handle
 Twitter API's [rate limits](https://dev.twitter.com/rest/public/rate-limiting)
 for you. In addition to letting you collect tweets Twarc can also help you
 collect users, trends and hydrate tweet ids.

--- a/README_es_mx.md
+++ b/README_es_mx.md
@@ -3,7 +3,7 @@
 *Traducciones: [Inglés], [Portugués], [Sueco], [Swahili]*
 
 Twarc es una recurso de línea de commando y catálogo de Python para archivar JSON dato de Twitter. Cada tweet se representa como
-un artículo de JSON que es [exactamente](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object) lo que fue capturado del API de Twitter. Los Tweets se archivan como [JSON de línea orientado](https://en.wikipedia.org/wiki/JSON_streaming#Line_delimited_JSON). Twarc se encarga del [límite de tarifa](https://developer.twitter.com/en/docs/basics/rate-limiting) del API de Twitter. Twarc también puede facilitar la colección de usuarios, tendencias y detallar las identificaciones de los tweets.
+un artículo de JSON que es [exactamente](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object) lo que fue capturado del API de Twitter. Los Tweets se archivan como [JSON de línea orientado](https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON). Twarc se encarga del [límite de tarifa](https://developer.twitter.com/en/docs/basics/rate-limiting) del API de Twitter. Twarc también puede facilitar la colección de usuarios, tendencias y detallar las identificaciones de los tweets.
 
 Twarc fue desarrollado como parte del proyecto [Documenting the Now](http://www.docnow.io/) el cual fue financiado por el [Mellon Foundation](https://mellon.org/).
 

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -8,7 +8,7 @@ twarc
 twarc é uma ferramenta de linha de comando e usa a biblioteca Python para arquivamento de dados do Twitter com JSON.
 Cada tweet será representado como um objeto JSON
 [exatamente](https://dev.twitter.com/overview/api/tweets) o que foi devolvido pela
-API do Twitter.  Os Tweets serão armazenados como [JSON, um por linha](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON).  Twarc controla totalmente a API [limites de uso](https://dev.twitter.com/rest/public/rate-limiting)
+API do Twitter.  Os Tweets serão armazenados como [JSON, um por linha](https://en.wikipedia.org/wiki/JSON_Streaming#Line-delimited_JSON).  Twarc controla totalmente a API [limites de uso](https://dev.twitter.com/rest/public/rate-limiting)
 para você. Além de permitir que você colete Tweets, Twarc também pode ajudá-lo
 Coletar usuários, tendências e hidratar tweet ids.
 

--- a/README_sv_se.md
+++ b/README_sv_se.md
@@ -7,7 +7,7 @@ twarc
 
 twarc är ett kommandoradsverktyg twarc och ett Pythonbibliotek för arkivering av Twitter JSON data.
 Varje tweet är representerat som ett JSON-objekt som är [exakt](https://dev.twitter.com/overview/api/tweets) vad som returneras från Twitters API
-Tweets lagras som [line-oriented JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON).  Twarc hanterar
+Tweets lagras som [line-oriented JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line-delimited_JSON).  Twarc hanterar
 Twitter API:ets [rate limits](https://dev.twitter.com/rest/public/rate-limiting)
 åt dig. Förutom att kunna samla in tweets kan även Twarc hjälpa dig att samla in användare, trender och omvandla tweet-id:n till tweets. 
 

--- a/README_sw_ke.md
+++ b/README_sw_ke.md
@@ -9,7 +9,7 @@ twarc ni chombo ya command-line na Python Library ya kuhifadhi Twitter JSON
 data. Kila Tweet ita akilishwa kama kitu ya JSON ita onyeshwa
 [hivi](https://dev.twitter.com/overview/api/tweets) kutoka kwa Twitter API.
 Tweets zita wekwa kama [line-oriented
-JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON). Twarc
+JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line-delimited_JSON). Twarc
 ita kusaidia ku chunga [rate
 limits](https://dev.twitter.com/rest/public/rate-limiting) ya API ya Twitter.
 Twarc pia ita sanya tweets, watumiaji wa Twitter, uwenendo za Twitter na ita


### PR DESCRIPTION
A while age, a hyphen was added to the "Line-delimited JSON" section
of the "JSON streaming" Wikipedia page that the README links to.
(https://en.wikipedia.org/w/index.php?title=JSON_streaming&type=revision&diff=prev&oldid=815227476)

This updates the links in all of the README files to use hyphens.