### PR TITLE
Fix typo in reference to `quoted_status_id_str`

### DIFF
--- a/twarc/client.py
+++ b/twarc/client.py
@@ -613,7 +613,7 @@ class Twarc(object):
         # if this tweet is a quote go get that too whatever tweets it
         # may be in reply to
 
-        quote_id = tweet.get('quotes_status_id_str')
+        quote_id = tweet.get('quoted_status_id_str')
         if recursive and quote_id and quote_id not in prune:
             t = self.tweet(quote_id)
             if t:


### PR DESCRIPTION
Hi there!

I was experimenting with twarc and noticed it looks for a `quotes_status_id_str` field on a tweet to find related threads. It looks like there is no `quotes_status_id_str` on a tweet, but there is a `quoted_status_id_str` that points to the tweet quoted in the current tweet. Is that what was meant here?