### PR TITLE
include accurate favorite counts for retweeted tweets

### DIFF
--- a/twarc/json2csv.py
+++ b/twarc/json2csv.py
@@ -71,7 +71,7 @@ def get_row(t, excel=False):
       hashtags(t),
       media(t),
       urls(t),
-      get('favorite_count'),
+      favorite_count(t),
       get('in_reply_to_screen_name'),
       get('in_reply_to_status_id'),
       get('in_reply_to_user_id'),
@@ -157,7 +157,12 @@ def retweet_user_id(t):
         return t['retweeted_status']['user']['id_str']
     elif 'quoted_status' in t and t['quoted_status']:
         return t['quoted_status']['user']['id_str']
-
+    
+def favorite_count(t):
+    if 'retweeted_status' in t and t['retweeted_status']:
+        return t['retweeted_status']['favorite_count']
+    else:
+        return t['favorite_count']
 
 def tweet_url(t):
     return "https://twitter.com/%s/status/%s" % (t['user']['screen_name'], t['id_str'])


### PR DESCRIPTION
When exploring tweet CSV files created with json2csv.py, I noticed that retweeted tweets contain the same "retweet_count" information as the original tweet but they do not contain the same "favorite_count" information. All retweeted tweets show up as having 0 favorites, even though the original tweet might have thousands of favorites.

This update includes accurate favorite counts for retweeted tweets AKA the same favorite count as the original tweet.