### PR TITLE
Support Twitter labs v1 sample endpoint

### DIFF
--- a/test_twarc.py
+++ b/test_twarc.py
@@ -631,7 +631,7 @@ def test_invalid_credentials():
     T.consumer_key = old_consumer_key
 
 def test_app_auth():
-    ta = twarc.Twarc(app_auth=True) 
+    ta = twarc.Twarc(app_auth=True)
     count = 0
     for tweet in ta.search('obama'):
         assert tweet['id_str']
@@ -639,3 +639,20 @@ def test_app_auth():
         if count == 10:
             break
     assert count == 10
+
+
+@pytest.mark.xfail
+def test_labs_v1_sample():
+    ta = twarc.Twarc(app_auth=True)
+
+    collected = 0
+
+    for tweet in ta.labs_v1_sample():
+        if 'data' in tweet:
+            collected += 1
+
+        if collected == 100:
+            break
+
+    # reconnect to close streaming connection for other tests
+    ta.connect()

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -284,7 +284,7 @@ class Twarc(object):
             for user_id in user_ids['ids']:
                 yield str_type(user_id)
             params['cursor'] = user_ids['next_cursor']
-            
+
             if max_pages is not None and retrieved_pages == max_pages:
                 log.info("reached max follower page limit for %s", params)
                 break
@@ -304,7 +304,7 @@ class Twarc(object):
             params = {'screen_name': user, 'cursor': -1}
 
         retrieved_pages = 0
-        
+
         while params['cursor'] != 0:
             try:
                 resp = self.get(url, params=params, allow_404=True)
@@ -324,7 +324,7 @@ class Twarc(object):
                 break
 
     @filter_protected
-    def filter(self, track=None, follow=None, locations=None, lang=[], 
+    def filter(self, track=None, follow=None, locations=None, lang=[],
                event=None, record_keepalive=False):
         """
         Returns an iterator for tweets that match a given filter track from
@@ -433,6 +433,76 @@ class Twarc(object):
                         continue
                     try:
                         yield json.loads(line.decode())
+                    except Exception as e:
+                        log.error("json parse error: %s - %s", e, line)
+            except requests.exceptions.HTTPError as e:
+                errors += 1
+                log.error("caught http error %s on %s try", e, errors)
+                if self.http_errors and errors == self.http_errors:
+                    log.warning("too many errors")
+                    raise e
+                if e.response.status_code == 420:
+                    if interruptible_sleep(errors * 60, event):
+                        log.info("stopping filter")
+                        return
+                else:
+                    if interruptible_sleep(errors * 5, event):
+                        log.info("stopping filter")
+                        return
+
+            except Exception as e:
+                errors += 1
+                log.error("caught exception %s on %s try", e, errors)
+                if self.http_errors and errors == self.http_errors:
+                    log.warning("too many errors")
+                    raise e
+                if interruptible_sleep(errors, event):
+                    log.info("stopping filter")
+                    return
+
+    def labs_v1_sample(self, event=None, record_keepalive=False):
+        """
+        Returns a small random sample of all public statuses, using the new Twitter
+        labs API version of the endpoint.
+
+        The Tweets returned by the default access level are the same, so if two
+        different clients connect to this endpoint, they will see the same Tweets.
+
+        If a threading.Event is provided for event and the event is set,
+        the sample will be interrupted.
+
+        Requires the use of application only authorisation (set app_auth=True on
+        constructing the Twarc client, or on the commandline).
+        """
+
+        if not self.app_auth:
+            raise RuntimeError(
+                "This endpoint is only available with application authentication. "
+                "Pass app_auth=True in Python or --app-auth on the command line."
+            )
+
+        url = 'https://api.twitter.com/labs/1/tweets/stream/sample'
+        headers = {'accept-encoding': 'deflate, gzip'}
+        errors = 0
+        while True:
+            try:
+                log.info("connecting to labs sample stream")
+                resp = self.get(url, labs_v1_call=True, headers=headers, stream=True)
+                errors = 0
+                for raw_line in resp.iter_lines(chunk_size=512):
+                    line = raw_line.decode()
+                    if event and event.is_set():
+                        log.info("stopping sample")
+                        # Explicitly close response
+                        resp.close()
+                        return
+                    if line == "":
+                        log.info("keep-alive")
+                        if record_keepalive:
+                            yield "keep-alive"
+                        continue
+                    try:
+                        yield json.loads(line)
                     except Exception as e:
                         log.error("json parse error: %s - %s", e, line)
             except requests.exceptions.HTTPError as e:
@@ -662,7 +732,7 @@ class Twarc(object):
     def oembed(self, tweet_url, **params):
         """
         Returns the oEmbed JSON for a tweet. The JSON includes an html
-        key that contains the HTML for the embed. You can pass in 
+        key that contains the HTML for the embed. You can pass in
         parameters that correspond to the paramters that Twitter's
         statuses/oembed endpoint supports. For example:
 
@@ -686,6 +756,12 @@ class Twarc(object):
 
         if "params" in kwargs:
             kwargs["params"]["tweet_mode"] = self.tweet_mode
+        elif "labs_v1_call" in kwargs:
+            # This is a v1 labs call, so we want to use format=detailed
+            # to capture as much as possible
+            kwargs["params"] = {"format": "detailed"}
+            # Don't pass this downstream to the requests call.
+            del kwargs["labs_v1_call"]
         else:
             kwargs["params"] = {"tweet_mode": self.tweet_mode}
 
@@ -773,12 +849,12 @@ class Twarc(object):
                 resource_owner_key=self.access_token,
                 resource_owner_secret=self.access_token_secret
             )
-        else: 
+        else:
             logging.info('creating OAuth2 app authentication')
             client = BackendApplicationClient(client_id=self.consumer_key)
             oauth = OAuth2Session(client=client)
             token = oauth.fetch_token(
-                token_url='https://api.twitter.com/oauth2/token', 
+                token_url='https://api.twitter.com/oauth2/token',
                 client_id=self.consumer_key,
                 client_secret=self.consumer_secret
             )

--- a/twarc/command.py
+++ b/twarc/command.py
@@ -49,6 +49,7 @@ commands = [
     'users',
     'listmembers',
     'version',
+    'labs_v1_sample',
 ]
 
 
@@ -148,6 +149,9 @@ def main():
 
     elif command == "sample":
         things = t.sample()
+
+    elif command == "labs_v1_sample":
+        things = t.labs_v1_sample()
 
     elif command == "timeline":
         kwargs = {"max_id": args.max_id, "since_id": args.since_id}
@@ -295,6 +299,9 @@ def main():
             log.warning(thing['warning']['message'])
             if args.warnings:
                 print(json.dumps(thing), file=fh)
+        elif 'data' in thing:
+            # Labs style JSON schema.
+            print(json.dumps(thing), file=fh)
 
 
 def get_argparser():
@@ -358,7 +365,7 @@ def get_argparser():
                         help="skip checking keys are valid on startup")
     parser.add_argument("--app_auth", action="store_true", default=False,
                         help="run in App Auth mode instead of User Auth")
-                        
+
 
     return parser
 


### PR DESCRIPTION
This is a work in progress to start figuring out how to support the new Twitter API as previewed in the labs endpoints. The motivating factor was to figure out how/if we could support [this covid endpoint for researchers](https://developer.twitter.com/en/docs/labs/covid19-stream/overview).

This ignores the problem of how to handle the data once collected - the focus here is just preserving the data as is, so options like CSV support aren't currently considered.

## Issues that are already handled:

1. Authentication - the recent addition of app only authentication covers authentication for many of the new endpoints :)
2. Not surprisingly most of the connection handling and retry logic is still appropriate - thought there will need to be some minor changes (see below).

## Issues to be resolved:

1. Data formats and handling: there are multiple options in the labs endpoint for controlling exactly what is returned. I think the options for twarc are to pick a comprehensive default for what can be archived, or maybe expose a way to configure this easily.

    - in the V1 endpoints there is a format option, which is either `compact`, `default` or `detailed`, with default returning the most information.
    - in the V2 endpoints, the format is replaced with `fields`, where you can specific a detailed list of fields to be included in the tweet.
    - There are also expansions (basically expanding a referenced object such as a quoted tweet or retweeted user directly in the response.)
    - The are also `annotations` which apply some magic to markup tweets with various entities (such as people and places).

2. How to support the current and labs endpoint in parallel and smoothly enable a transition between them. 

    - I think we can add all of the labs endpoints as additional methods, living side by side with existing methods - there will be work required to make sure all of the argument handling is consistent 
    - This also lets us handle v1, v2 and whatever else comes next on an
    endpoint by endpoint basis.

3. I think the twarc client get and post methods probably need a little bit of work to better handle points 1 and 2, and new failure modes:

    - probably need a nicer way to handle different parameters for labs v1 + v2 alongside the existing endpoints
    - need to review any new errors and failure modes - for example some endpoints have a new monthly cap on the number of tweets transferred
