### PR TITLE
Provide getting started message to client on first run.

### DIFF
--- a/twarc/client.py
+++ b/twarc/client.py
@@ -836,7 +836,9 @@ class Twarc(object):
                 else:
                     raise e
         else:
-            raise RuntimeError('Incomplete credentials provided.')
+            print('Incomplete credentials provided.')
+            print('Please run the command "twarc configure" to get started.')
+            sys.exit()
 
     def load_config(self):
         path = self.config


### PR DESCRIPTION
Re:#330, a more user-friendly solution to showing a stack trace when credentials have not been provided.

There are more elegant models to handle this, but I noticed that the scenario for invalid credentials and general errors were throwing exceptions earlier in the function. The rationale here is to terminate quickly instead of bubbling up the exception handling logic to the caller.

Closes #330 

Ping @edsu 