### PR TITLE
Update unshrtn script to expand user profile URLs

### DIFF
--- a/utils/unshrtn.py
+++ b/utils/unshrtn.py
@@ -75,10 +75,6 @@ def rewrite_line(line):
         logging.error(e)
         return line
 
-    # don't do the same work again
-    if "unshortened_url" in tweet and tweet["unshortened_url"]:
-        return line
-
     for url_dict in tweet["entities"]["urls"]:
         if "expanded_url" in url_dict:
             url = url_dict["expanded_url"]

--- a/utils/unshrtn.py
+++ b/utils/unshrtn.py
@@ -32,23 +32,32 @@ wait = 15
 
 logging.basicConfig(filename="unshorten.log", level=logging.INFO)
 
+
 def unshorten_url(url):
     if url is None:
         return None
 
     # TODO: Worth providing some way for the user to specify specific hostnames they want to expand,
     # instead of assuming that all hostnames need expanding?
-    if re.match(r'^https?://twitter.com/', url):
+    if re.match(r"^https?://twitter.com/", url):
         return url
 
-    u = '{}/?{}'.format(unshrtn_url, urllib.parse.urlencode({'url': url.encode('utf8')}))
+    u = "{}/?{}".format(
+        unshrtn_url, urllib.parse.urlencode({"url": url.encode("utf8")})
+    )
     resp = None
     for retry in range(0, retries):
         try:
-            resp = json.loads(urllib.request.urlopen(u).read().decode('utf-8'))
+            resp = json.loads(urllib.request.urlopen(u).read().decode("utf-8"))
             break
         except Exception as e:
-            logging.error("http error: %s when looking up %s. Try %s of %s", e, url, retry, retries)
+            logging.error(
+                "http error: %s when looking up %s. Try %s of %s",
+                e,
+                url,
+                retry,
+                retries,
+            )
             time.sleep(wait)
 
     for key in ["canonical", "long"]:
@@ -56,6 +65,7 @@ def unshorten_url(url):
             return resp[key]
 
     return None
+
 
 def rewrite_line(line):
     try:
@@ -66,16 +76,16 @@ def rewrite_line(line):
         return line
 
     # don't do the same work again
-    if 'unshortened_url' in tweet and tweet['unshortened_url']:
+    if "unshortened_url" in tweet and tweet["unshortened_url"]:
         return line
 
     for url_dict in tweet["entities"]["urls"]:
         if "expanded_url" in url_dict:
             url = url_dict["expanded_url"]
         else:
-            url = url_dict['url']
+            url = url_dict["url"]
 
-        url_dict['unshortened_url'] = unshorten_url(url)
+        url_dict["unshortened_url"] = unshorten_url(url)
 
     tweet["user"]["unshortened_url"] = unshorten_url(tweet["user"]["url"])
 
@@ -85,21 +95,45 @@ def rewrite_line(line):
 def main():
     global unshrtn_url, retries, wait
     parser = argparse.ArgumentParser()
-    parser.add_argument('--pool-size', help='number of urls to look up in parallel', default=POOL_SIZE, type=int)
-    parser.add_argument('--unshrtn', help='url of the unshrtn service', default=unshrtn_url)
-    parser.add_argument('--retries', help='number of time to retry if error from unshrtn service', default=retries,
-                        type=int)
-    parser.add_argument('--wait', help='number of seconds to wait between retries if error from unshrtn service',
-                        default=wait, type=int)
-    parser.add_argument('files', metavar='FILE', nargs='*', help='files to read, if empty, stdin is used')
+    parser.add_argument(
+        "--pool-size",
+        help="number of urls to look up in parallel",
+        default=POOL_SIZE,
+        type=int,
+    )
+    parser.add_argument(
+        "--unshrtn", help="url of the unshrtn service", default=unshrtn_url
+    )
+    parser.add_argument(
+        "--retries",
+        help="number of time to retry if error from unshrtn service",
+        default=retries,
+        type=int,
+    )
+    parser.add_argument(
+        "--wait",
+        help="number of seconds to wait between retries if error from unshrtn service",
+        default=wait,
+        type=int,
+    )
+    parser.add_argument(
+        "files",
+        metavar="FILE",
+        nargs="*",
+        help="files to read, if empty, stdin is used",
+    )
     args = parser.parse_args()
 
     unshrtn_url = args.unshrtn
     retries = args.retries
     wait = args.wait
     pool = multiprocessing.Pool(args.pool_size)
-    for line in pool.imap_unordered(rewrite_line, fileinput.input(files=args.files if len(args.files) > 0 else ('-',))):
-        if line != "\n": print(line)
+    for line in pool.imap_unordered(
+        rewrite_line,
+        fileinput.input(files=args.files if len(args.files) > 0 else ("-",)),
+    ):
+        if line != "\n":
+            print(line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sometimes, the user profile URL is shortened (either by Twitter into a `t.co` link or manually by the user). This PR factors the unshortening code out of the `rewrite_line` function in order to apply it to both `tweet["entities"]["urls"]` as well as `tweet["user"]["url"]`.

Open questions:
* Should there be a way to specify which hostnames are unshortened/which are excluded? Currently, `twitter.com` URLs are excluded, but I could imagine someone wanting to only unshorten `t.co` URLs.
* I removed the check that skips unshortening lines that have already been unshortened, as I don't think it was working in the first place (it checked for `tweet["unshortened_url"]`, but the unshortened urls were previously written to `tweet["entities"]["urls"][n]["unshortened_url"]`) and would now also need to check for profile urls. (I can reimplement it if we think it's necessary, but I'm not sure it is given that unshrtn caches.)

(Made with some guidance from @lxcode.)