### PR TITLE
v2: fix metadata not being included on first page

### DIFF
--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -443,6 +443,12 @@ class Twarc2:
         page = self.get(*args, **kwargs).json()
 
         url = args[0]
+        
+        if self.metadata:
+            page["__twarc"] = {
+                "url": url,
+                "retrieved_at": _utcnow()
+            }
 
         yield page
 

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -199,8 +199,8 @@ def flatten(response):
     if "data" in response:
         response["data"] = expand_payload(response["data"])
 
-    # Add the __twarc metadata from the response to each tweet
-    if "__twarc" in response:
+    # Add the __twarc metadata from the response to each tweet if it's a result set
+    if "__twarc" in response and isinstance(response["data"], list):
         for tweet in response["data"]:
             tweet["__twarc"] = response["__twarc"]
 

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -199,4 +199,9 @@ def flatten(response):
     if "data" in response:
         response["data"] = expand_payload(response["data"])
 
+    # Add the __twarc metadata from the response to each tweet
+    if "__twarc" in response:
+        for tweet in response["data"]:
+            tweet["__twarc"] = response["__twarc"]
+
     return response


### PR DESCRIPTION
For paginated results, `__twarc` metadata was not being included on the first page of the results.