### PR TITLE
Skip tests for docs changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: tests
-on: [push]
+on:
+  push:
+    paths-ignore:
+    - 'docs/**'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a small change just to stop the tests from running any time there's a change to the docs, which may be more frequent. I think it's useful to speed up docs only changes.