### PR TITLE
fix flatten command overwriting input file #436

### DIFF
--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -359,8 +359,8 @@ def flatten(infile, outfile):
     "Flatten" tweets, or move expansions inline with tweet objects.
     """
     if (infile.name == outfile.name):
-        outfile.name = outfile.name + '_flattened.jsonl'
-        click.echo(click.style(f"💔 Cannot flatten files in-place, writing to a new file instead: {outfile.name}", fg='red'), err=True)
+        click.echo(click.style(f"💔 Cannot flatten files in-place, specify a different output file!", fg='red'), err=True)
+        return
 
     for line in infile:
         result = json.loads(line)

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -358,6 +358,10 @@ def flatten(infile, outfile):
     """
     "Flatten" tweets, or move expansions inline with tweet objects.
     """
+    if (infile.name == outfile.name):
+        outfile.name = outfile.name + '_flattened.jsonl'
+        click.echo(click.style(f"💔 Cannot flatten files in-place, writing to a new file instead: {outfile.name}", fg='red'), err=True)
+
     for line in infile:
         result = json.loads(line)
         _write(result, outfile, True)


### PR DESCRIPTION
Fixes #436 and shows a warning and writes to a different file instead.

Doesn't write the warning out if using pipes, so `cat tweets.json | twarc2 flatten` still works