### PR TITLE
Check for since-id use when assuming start-time

### DIFF
--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -181,7 +181,7 @@ def search(T, query, outfile, since_id, until_id, start_time, end_time, limit,
         # if the user is searching the historical archive the assumption is that
         # they want to search everything, and not just the previous month which
         # is the default: https://github.com/DocNow/twarc/issues/434
-        if start_time == None:
+        if start_time == None and since_id == None:
             start_time = datetime.datetime(2006, 3, 21, tzinfo=datetime.timezone.utc)
     else:
         if max_results == 0:


### PR DESCRIPTION
If you try to use `--since-id` and `--until-id` instead of `--start-time` and `--end-time` it will fail with 
`⚡ Invalid use of 'since_id' or 'until_id' in conjunction with 'start_time' or 'end_time'.` because it will set start time to the 2006 date.

For example:

```
twarc2 search --since-id 947277536320405504 --until-id 966797201685938176 --archive "..."
```

not setting `--start-time` if `--since-id` is set fixes this.