### PR TITLE
Allow twarc to run as module

### DIFF
--- a/twarc/__main__.py
+++ b/twarc/__main__.py
@@ -1,0 +1,5 @@
+import twarc.command
+
+if __name__ == "__main__":
+    twarc.command.main()
+

--- a/twarc2.py
+++ b/twarc2.py
@@ -1,0 +1,4 @@
+from twarc.command2 import twarc2
+
+if __name__ == "__main__":
+    twarc2(prog_name="python -m twarc2")


### PR DESCRIPTION
following on from https://github.com/DocNow/twarc/issues/441#issuecomment-832876616 

It's possible to make it so that these commands are equivalent:

```
twarc2 version
python -m twarc2 version
twarc2.exe version
```

```
twarc version
python -m twarc version
twarc.exe version
```

I'm not sure how generally useful this is but i found it helped because i could run a profiler (slightly) easier, for example:

```
python -m cProfile -s cumulative -m twarc2 csv big_test.jsonl big_test.csv
```

It's not a terribly critical improvement either way, but it was a very small change with some boilerplate files.