### PR TITLE
Don't show bytes b prefix

### DIFF
--- a/utils/source.py
+++ b/utils/source.py
@@ -5,7 +5,6 @@ Util to count which clients are most used.
 Example usage:
 utils/source.py tweets.jsonl > sources.html
 """
-from __future__ import print_function
 import json
 import fileinput
 from collections import defaultdict
@@ -55,14 +54,14 @@ print("""<!doctype html>
 
   <header>
   <h1>Twitter client sources</h1>
-  <em>created on the command line with <a href="http://github.com/edsu/twarc">twarc</a></em>
+  <em>created on the command line with <a href="https://github.com/DocNow/twarc">twarc</a></em>
   </header>
 
   <table>
 """)
 
 for source in sumsort:
-    print('<tr><td>{}</td><td>{}</td></tr>'.format(source.encode('utf-8'), summary[source]))
+    print('<tr><td>{}</td><td>{}</td></tr>'.format(source, summary[source]))
 print("""
 
 
@@ -71,7 +70,7 @@ print("""
 <footer id="page">
 <hr>
 <br>
-created on the command line with <a href="http://github.com/edsu/twarc">twarc</a>.
+created on the command line with <a href="https://github.com/DocNow/twarc">twarc</a>.
 <br>
 <br>
 </footer>


### PR DESCRIPTION
```sh
python utils/source.py tweets.jsonl > sources.html
```

# Before

![image](https://user-images.githubusercontent.com/1324225/121801280-376f9e80-cc3f-11eb-8a05-bcc6522cf104.png)

# After

![image](https://user-images.githubusercontent.com/1324225/121801284-3ccce900-cc3f-11eb-8999-b51edee67fb1.png)

As only Python 3.3+ is supported, no need to support Python 2.

I've only tested on macOS, is extra handling needed for Windows?

Also update homepage URL.


And is it time to only [support 3.6](https://endoflife.date/python)? Could then use some newer things like f-strings.