### PR TITLE
wall.py: Fix username regex and show likes

### DIFF
--- a/utils/wall.py
+++ b/utils/wall.py
@@ -168,7 +168,7 @@ for line in lines:
         start, end = url['indices']
         t['text'] = t['text'][0:start] + a + t['text'][end:]
 
-    t['text'] = re.sub(' @([^ ]+)', r' <a href="https://twitter.com/\g<1>">@\g<1></a>', t['text'])
+    t['text'] = re.sub('@([A-Za-z0-9_]+)', r'<a href="https://twitter.com/\g<1>">@\g<1></a>', t['text'])
     t['text'] = re.sub(' #([^ ]+)', r' <a href="https://twitter.com/search?q=%23\g<1>&src=hash">#\g<1></a>', t['text'])
 
     html = """

--- a/utils/wall.py
+++ b/utils/wall.py
@@ -185,10 +185,7 @@ for line in lines:
     </article>
     """ % t
 
-    if sys.version_info.major == 2:
-        print(html.encode('utf8'))
-    else:
-        print(html)
+    print(html)
 
 print("""
 

--- a/utils/wall.py
+++ b/utils/wall.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Feed wall.py your JSON and get a wall of tweets as HTML. If you want to get the
@@ -8,7 +7,6 @@ wall in chronological order, a handy trick is:
     % tail -r tweets.jsonl | ./wall.py > wall.html
 
 """
-from __future__ import print_function
 
 import os
 import re
@@ -170,10 +168,10 @@ for line in lines:
         start, end = url['indices']
         t['text'] = t['text'][0:start] + a + t['text'][end:]
 
-    t['text'] = re.sub(' @([^ ]+)', ' <a href="https://twitter.com/\g<1>">@\g<1></a>', t['text'])
-    t['text'] = re.sub(' #([^ ]+)', ' <a href="https://twitter.com/search?q=%23\g<1>&src=hash">#\g<1></a>', t['text'])
+    t['text'] = re.sub(' @([^ ]+)', r' <a href="https://twitter.com/\g<1>">@\g<1></a>', t['text'])
+    t['text'] = re.sub(' #([^ ]+)', r' <a href="https://twitter.com/search?q=%23\g<1>&src=hash">#\g<1></a>', t['text'])
 
-    html = u"""
+    html = """
     <article class="tweet">
       <img class="avatar" src="%(avatar)s">
       <a href="%(user_url)s" class="name">%(name)s</a><br>

--- a/utils/wall.py
+++ b/utils/wall.py
@@ -111,7 +111,7 @@ print("""<!doctype html>
 
   <header>
   <h1>Title Here</h1>
-  <em>created on the command line with <a href="http://github.com/edsu/twarc">twarc</a></em>
+  <em>created on the command line with <a href="https://github.com/DocNow/twarc">twarc</a></em>
   </header>
 
   <div id="tweets">
@@ -149,10 +149,10 @@ for line in lines:
         "created_at": tweet["created_at"],
         "name": tweet["user"]["name"],
         "username": tweet["user"]["screen_name"],
-        "user_url": "http://twitter.com/" + tweet["user"]["screen_name"],
+        "user_url": "https://twitter.com/" + tweet["user"]["screen_name"],
         "text": text(tweet),
         "avatar": AVATAR_DIR + "/" + filename,
-        "url": "http://twitter.com/" + tweet["user"]["screen_name"] + "/status/" + tweet["id_str"],
+        "url": "https://twitter.com/" + tweet["user"]["screen_name"] + "/status/" + tweet["id_str"],
     }
 
     if 'retweet_status' in tweet:
@@ -170,7 +170,7 @@ for line in lines:
         start, end = url['indices']
         t['text'] = t['text'][0:start] + a + t['text'][end:]
 
-    t['text'] = re.sub(' @([^ ]+)', ' <a href="http://twitter.com/\g<1>">@\g<1></a>', t['text'])
+    t['text'] = re.sub(' @([^ ]+)', ' <a href="https://twitter.com/\g<1>">@\g<1></a>', t['text'])
     t['text'] = re.sub(' #([^ ]+)', ' <a href="https://twitter.com/search?q=%23\g<1>&src=hash">#\g<1></a>', t['text'])
 
     html = u"""
@@ -199,7 +199,7 @@ print("""
 <footer id="page">
 <hr>
 <br>
-created on the command line with <a href="http://github.com/edsu/twarc">twarc</a>.
+created on the command line with <a href="https://github.com/DocNow/twarc">twarc</a>.
 <br>
 <br>
 </footer>

--- a/utils/wall.py
+++ b/utils/wall.py
@@ -158,10 +158,9 @@ for line in lines:
     else:
         t['retweet_count'] = tweet.get('retweet_count', 0)
 
-    if t['retweet_count'] == 1:
-        t['retweet_string'] = 'retweet'
-    else:
-        t['retweet_string'] = 'retweets'
+    t['favorite_count'] = tweet.get('favorite_count', 0)
+    t['retweet_string'] = 'retweet' if t['retweet_count'] == 1 else 'retweets'
+    t['favorite_string'] = 'like' if t['favorite_count'] == 1 else 'likes'
 
     for url in tweet['entities']['urls']:
         a = '<a href="%(expanded_url)s">%(url)s</a>' % url
@@ -179,7 +178,7 @@ for line in lines:
       <br>
       <div class="text">%(text)s</div><br>
       <footer>
-      %(retweet_count)s %(retweet_string)s<br>
+      %(retweet_count)s %(retweet_string)s, %(favorite_count)s %(favorite_string)s<br>
       <a href="%(url)s"><time>%(created_at)s</time></a>
       </footer>
     </article>


### PR DESCRIPTION
https://help.twitter.com/en/managing-your-account/twitter-username-rules says:

> A username can only contain alphanumeric characters (letters A-Z, numbers 0-9) with the exception of underscores, as noted above. Check to make sure your desired username doesn't contain any symbols, dashes, or spaces.

So that's `[A-Za-z0-9_]+`

# Before

The existing one has a couple of problems:

* The first username in a tweet isn't linked, for example b3703742 in the second tweet, similarly in the third and sixth tweets
* Colons are included in link, for example the first links `b3703742:` to `https://twitter.com/b3703742:`, similarly in the fourth and fifth

![image](https://user-images.githubusercontent.com/1324225/121803649-51af7980-cc4b-11eb-9aac-2d5e025fc66c.png)

# After

Fix those and show likes:

![image](https://user-images.githubusercontent.com/1324225/121810978-7ca9c580-cc6b-11eb-97ea-5dbffc7bd4de.png)


Also update twarc and HTTPS URLs and upgrade for Python 3+.
