### PR TITLE
Progress Bars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python-dateutil
 requests_oauthlib
 tqdm
+humanize
 click
 click-plugins
 click-config-file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 python-dateutil
 requests_oauthlib
+tqdm
 click
 click-plugins
 click-config-file

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -861,7 +861,7 @@ class Twarc2:
                 resource_owner_secret=self.access_token_secret,
             )
 
-    def _id_exists(user):
+    def _id_exists(self, user):
         """
         Returns True if the user id exists
         """

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -747,7 +747,7 @@ class Twarc2:
             exclude_replies,
         )
 
-    def following(self, user):
+    def following(self, user, user_id=None):
         """
         Retrieve the user profiles of accounts followed by the given user.
 
@@ -759,13 +759,13 @@ class Twarc2:
         Returns:
             generator[dict]: A generator, dict for each page of results.
         """
-        user_id = self._ensure_user_id(user)
+        user_id = self._ensure_user_id(user) if not user_id else user_id
         params = expansions.USER_EVERYTHING.copy()
         params["max_results"] = 1000
         url = f"https://api.twitter.com/2/users/{user_id}/following"
         return self.get_paginated(url, params=params)
 
-    def followers(self, user):
+    def followers(self, user, user_id=None):
         """
         Retrieve the user profiles of accounts following the given user.
 
@@ -777,7 +777,7 @@ class Twarc2:
         Returns:
             generator[dict]: A generator, dict for each page of results.
         """
-        user_id = self._ensure_user_id(user)
+        user_id = self._ensure_user_id(user) if not user_id else user_id
         params = expansions.USER_EVERYTHING.copy()
         params["max_results"] = 1000
         url = f"https://api.twitter.com/2/users/{user_id}/followers"

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -198,7 +198,7 @@ class Twarc2:
         until_id=None,
         start_time=None,
         end_time=None,
-        max_results=100, # temp fix for #504
+        max_results=100,  # temp fix for #504
     ):
         """
         Search Twitter for the given query in the full archive,

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -5,7 +5,6 @@ Support for the Twitter v2 API.
 """
 
 import re
-import ssl
 import json
 import time
 import logging

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -878,7 +878,7 @@ class Twarc2:
         user = str(user)
         is_numeric = re.match(r"^\d+$", user)
 
-        if len(user) > 15 or (is_numeric and _id_exists(user)):
+        if len(user) > 15 or (is_numeric and self._id_exists(user)):
             return user
         else:
             results = next(self.user_lookup([user], usernames=True))
@@ -897,7 +897,7 @@ class Twarc2:
         is_numeric = re.match(r"^\d+$", user)
 
         lookup = []
-        if len(user) > 15 or (is_numeric and _id_exists(user)):
+        if len(user) > 15 or (is_numeric and self._id_exists(user)):
             lookup = expansions.ensure_flattened(list(self.user_lookup([user])))
         else:
             lookup = expansions.ensure_flattened(

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -23,8 +23,6 @@ from twarc.version import version
 
 log = logging.getLogger("twarc")
 
-TWITTER_EPOCH = datetime.datetime(2006, 3, 21, tzinfo=datetime.timezone.utc)
-
 
 class Twarc2:
     """
@@ -227,12 +225,6 @@ class Twarc2:
         """
         url = "https://api.twitter.com/2/tweets/search/all"
 
-        # start time defaults to the beginning of Twitter to override the
-        # default of the last month. Only do this if start_time is not already
-        # specified and since_id isn't being used
-        if start_time is None and since_id is None:
-            start_time = TWITTER_EPOCH
-
         return self._search(
             url,
             query,
@@ -318,12 +310,6 @@ class Twarc2:
             generator[dict]: a generator, dict for each paginated response.
         """
         url = "https://api.twitter.com/2/tweets/counts/all"
-
-        # start time defaults to the beginning of Twitter to override the
-        # default of the last month. Only do this if start_time is not already
-        # specified and since_id isn't being used
-        if start_time is None and since_id is None:
-            start_time = TWITTER_EPOCH
 
         return self._search(
             url,

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -2,7 +2,6 @@
 The command line interfact to the Twitter v2 API.
 """
 
-import os
 import re
 import json
 import twarc
@@ -15,7 +14,6 @@ import threading
 
 from tqdm.auto import tqdm
 from datetime import timezone
-from urllib.parse import quote
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -12,6 +12,7 @@ import pathlib
 import configobj
 import threading
 
+from tqdm.auto import tqdm
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 
@@ -308,16 +309,9 @@ def search(
     "--text",
     is_flag=True,
     default=False,
-    help="Output the counts as human readable text"
+    help="Output the counts as human readable text",
 )
-@click.option(
-    "--csv",
-    is_flag=True,
-    default=False,
-    help="Output counts as CSV"
-)
-
-
+@click.option("--csv", is_flag=True, default=False, help="Output counts as CSV")
 @click.argument("query", type=str)
 @click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
@@ -334,7 +328,7 @@ def counts(
     granularity,
     limit,
     text,
-    csv
+    csv,
 ):
     """
     Return counts of tweets matching a query.
@@ -347,7 +341,7 @@ def counts(
         count_method = T.counts_recent
 
     if csv:
-        click.echo(f'start,end,{granularity}_count', file=outfile)
+        click.echo(f"start,end,{granularity}_count", file=outfile)
 
     total_tweets = 0
 
@@ -360,11 +354,11 @@ def counts(
         granularity,
     ):
         if text:
-            for r in result['data']:
-                total_tweets += r['tweet_count']
-                click.echo('{start} - {end}: {tweet_count:,}'.format(**r), file=outfile)
+            for r in result["data"]:
+                total_tweets += r["tweet_count"]
+                click.echo("{start} - {end}: {tweet_count:,}".format(**r), file=outfile)
         elif csv:
-            for r in result['data']:
+            for r in result["data"]:
                 click.echo(f'{r["start"]},{r["end"]},{r["tweet_count"]}', file=outfile)
         else:
             _write(result, outfile)
@@ -374,11 +368,8 @@ def counts(
 
         if text:
             click.echo(
-                click.style(
-                    '\nTotal Tweets: {:,}\n'.format(total_tweets),
-                    fg='green'
-                ),
-                file=outfile
+                click.style("\nTotal Tweets: {:,}\n".format(total_tweets), fg="green"),
+                file=outfile,
             )
 
 
@@ -401,7 +392,11 @@ def tweet(T, tweet_id, outfile, pretty):
 
 
 @twarc2.command("followers")
-@click.option("--limit", default=0, help="Maximum number of followers to save. Increments of 1000.")
+@click.option(
+    "--limit",
+    default=0,
+    help="Maximum number of followers to save. Increments of 1000.",
+)
 @click.option(
     "--hide-progress",
     is_flag=True,
@@ -422,7 +417,7 @@ def followers(T, user, outfile, limit, hide_progress):
 
     if not hide_progress:
         target_user = T._ensure_user(user)
-        user_id = target_user['id']
+        user_id = target_user["id"]
         lookup_total = target_user["public_metrics"]["followers_count"]
 
     with tqdm(disable=hide_progress, total=lookup_total) as progress:
@@ -435,7 +430,9 @@ def followers(T, user, outfile, limit, hide_progress):
 
 
 @twarc2.command("following")
-@click.option("--limit", default=0, help="Maximum number of friends to save. Increments of 1000.")
+@click.option(
+    "--limit", default=0, help="Maximum number of friends to save. Increments of 1000."
+)
 @click.option(
     "--hide-progress",
     is_flag=True,
@@ -456,7 +453,7 @@ def following(T, user, outfile, limit, hide_progress):
 
     if not hide_progress:
         target_user = T._ensure_user(user)
-        user_id = target_user['id']
+        user_id = target_user["id"]
         lookup_total = target_user["public_metrics"]["following_count"]
 
     with tqdm(disable=hide_progress, total=lookup_total) as progress:

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -321,7 +321,7 @@ def followers(T, user, outfile, limit):
 
 @twarc2.command("following")
 @click.option("--limit", default=0, help="Maximum number of friends to save")
-@click.argument("userd", type=str)
+@click.argument("user", type=str)
 @click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -696,18 +696,6 @@ def timeline(
     Retrieve recent tweets for the given user.
     """
 
-    tweets = _timeline_tweets(
-        T,
-        use_search,
-        user_id,
-        since_id,
-        until_id,
-        start_time,
-        end_time,
-        exclude_retweets,
-        exclude_replies,
-    )
-
     count = 0
 
     pbar = tqdm
@@ -725,6 +713,18 @@ def timeline(
             "end_time": end_time,
             "disable": hide_progress,
         }
+
+    tweets = _timeline_tweets(
+        T,
+        use_search,
+        user_id,
+        since_id,
+        until_id,
+        start_time,
+        end_time,
+        exclude_retweets,
+        exclude_replies,
+    )
 
     with pbar(**pbar_params) as progress:
         for result in tweets:
@@ -896,7 +896,7 @@ def _timeline_tweets(
             q += " -is:retweet"
         if exclude_replies and "-is:reply" not in q:
             q += " -is:reply"
-        tweets = T.search_all(q, since_id, until_id, start_time, end_time)
+        tweets = T.search_all(q, since_id, until_id, start_time, end_time, 100)
     else:
         tweets = T.timeline(
             user_id,

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -236,7 +236,7 @@ def _search(
 
         # default number of tweets per response 500 when not set otherwise
         if max_results == 0:
-            max_results = 100, # temp fix for #504
+            max_results = (100,)  # temp fix for #504
 
         # start time defaults to the beginning of Twitter to override the
         # default of the last month. Only do this if start_time is not already

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -470,6 +470,9 @@ def followers(T, user, outfile, limit, hide_progress):
     user_id = None
     lookup_total = 0
 
+    if outfile is not None and (outfile.name == "<stdout>"):
+        hide_progress = True
+
     if not hide_progress:
         target_user = T._ensure_user(user)
         user_id = target_user["id"]
@@ -481,6 +484,7 @@ def followers(T, user, outfile, limit, hide_progress):
             count += len(result["data"])
             progress.update(len(result["data"]))
             if limit != 0 and count >= limit:
+                progress.desc = f"Set --limit of {limit} reached"
                 break
 
 
@@ -506,6 +510,9 @@ def following(T, user, outfile, limit, hide_progress):
     user_id = None
     lookup_total = 0
 
+    if outfile is not None and (outfile.name == "<stdout>"):
+        hide_progress = True
+
     if not hide_progress:
         target_user = T._ensure_user(user)
         user_id = target_user["id"]
@@ -517,6 +524,7 @@ def following(T, user, outfile, limit, hide_progress):
             count += len(result["data"])
             progress.update(len(result["data"]))
             if limit != 0 and count >= limit:
+                progress.desc = f"Set --limit of {limit} reached"
                 break
 
 

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -417,12 +417,21 @@ def followers(T, user, outfile, limit, hide_progress):
     Get the followers for a given user.
     """
     count = 0
+    user_id = None
+    lookup_total = 0
 
-    for result in T.followers(user):
-        _write(result, outfile)
-        count += len(result["data"])
-        if limit != 0 and count >= limit:
-            break
+    if not hide_progress:
+        target_user = T._ensure_user(user)
+        user_id = target_user['id']
+        lookup_total = target_user["public_metrics"]["followers_count"]
+
+    with tqdm(disable=hide_progress, total=lookup_total) as progress:
+        for result in T.followers(user, user_id=user_id):
+            _write(result, outfile)
+            count += len(result["data"])
+            progress.update(len(result["data"]))
+            if limit != 0 and count >= limit:
+                break
 
 
 @twarc2.command("following")
@@ -442,12 +451,21 @@ def following(T, user, outfile, limit, hide_progress):
     Get the users who are following a given user.
     """
     count = 0
+    user_id = None
+    lookup_total = 0
 
-    for result in T.following(user):
-        _write(result, outfile)
-        count += len(result["data"])
-        if limit != 0 and count >= limit:
-            break
+    if not hide_progress:
+        target_user = T._ensure_user(user)
+        user_id = target_user['id']
+        lookup_total = target_user["public_metrics"]["following_count"]
+
+    with tqdm(disable=hide_progress, total=lookup_total) as progress:
+        for result in T.following(user, user_id=user_id):
+            _write(result, outfile)
+            count += len(result["data"])
+            progress.update(len(result["data"]))
+            if limit != 0 and count >= limit:
+                break
 
 
 @twarc2.command("sample")

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -293,6 +293,8 @@ def _search(
             if limit != 0 and count >= limit:
                 # Display message when stopped early
                 progress.desc = f"Set --limit of {limit} reached"
+                if isinstance(pbar, TimestampProgressBar):
+                    progress.early_stop = True
                 break
 
 

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -700,11 +700,16 @@ def timeline(
 
     pbar = tqdm
     user = T._ensure_user(user_id)
-    pbar_params = {"disable": hide_progress, "total": user["public_metrics"]["tweet_count"]}
+    pbar_params = {
+        "disable": hide_progress,
+        "total": user["public_metrics"]["tweet_count"],
+    }
 
     if use_search:
         if start_time is None and since_id is None:
-            start_time = datetime.datetime.strptime(user["created_at"], '%Y-%m-%dT%H:%M:%S.%fZ')
+            start_time = datetime.datetime.strptime(
+                user["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
         pbar = TimestampProgressBar
         pbar_params = {
             "since_id": since_id,

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -662,7 +662,7 @@ def delete_all(T):
         click.echo(f"🗑  Deleted {len(rule_ids)} rules.")
 
 
-def _id_progress_bar():
+def _id_progress_bar(since_id, until_id, start_time, end_time):
     """
     Snowflake ID based progress bar.
     """

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -401,7 +401,7 @@ def tweet(T, tweet_id, outfile, pretty):
 
 
 @twarc2.command("followers")
-@click.option("--limit", default=0, help="Maximum number of followers to save")
+@click.option("--limit", default=0, help="Maximum number of followers to save. Increments of 1000.")
 @click.option(
     "--hide-progress",
     is_flag=True,
@@ -426,7 +426,7 @@ def followers(T, user, outfile, limit, hide_progress):
 
 
 @twarc2.command("following")
-@click.option("--limit", default=0, help="Maximum number of friends to save")
+@click.option("--limit", default=0, help="Maximum number of friends to save. Increments of 1000.")
 @click.option(
     "--hide-progress",
     is_flag=True,

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -28,7 +28,6 @@ from twarc.decorators2 import (
     cli_api_error,
     TimestampProgressBar,
     FileSizeProgressBar,
-    _time_delta,
 )
 
 

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -250,7 +250,9 @@ def _search(
         count_method = T.counts_recent
 
     hide_progress = True if (outfile.name == "<stdout>") else hide_progress
-    short_timespan = abs(_time_delta(since_id, until_id, start_time, end_time).days) < 30
+    short_timespan = (
+        abs(_time_delta(since_id, until_id, start_time, end_time).days) < 30
+    )
     pbar = TimestampProgressBar(
         since_id, until_id, start_time, end_time, disable=hide_progress
     )

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -561,7 +561,7 @@ def hydrate(T, infile, outfile, hide_progress):
     """
     Hydrate tweet ids.
     """
-    with FileSizeProgressBar(infile, disable=hide_progress) as progress:
+    with FileSizeProgressBar(infile, outfile, disable=hide_progress) as progress:
         for result in T.tweet_lookup(infile):
             _write(result, outfile)
             tweet_ids = [t["id"] for t in result.get("data", [])]
@@ -585,7 +585,7 @@ def users(T, infile, outfile, usernames, hide_progress):
     """
     Get data for user ids or usernames.
     """
-    with FileSizeProgressBar(infile, disable=hide_progress) as progress:
+    with FileSizeProgressBar(infile, outfile, disable=hide_progress) as progress:
         for result in T.user_lookup(infile, usernames):
             _write(result, outfile)
             if usernames:
@@ -696,7 +696,7 @@ def timeline(
     """
 
     count = 0
-    user = T._ensure_user(user_id) # It's possible to skip this to optimize more
+    user = T._ensure_user(user_id)  # It's possible to skip this to optimize more
 
     if use_search or (start_time or end_time) or (since_id or until_id):
         pbar = TimestampProgressBar
@@ -826,7 +826,7 @@ def timelines(
     line_count = 0
     seen = set()
 
-    with FileSizeProgressBar(infile, disable=hide_progress) as progress:
+    with FileSizeProgressBar(infile, outfile, disable=hide_progress) as progress:
         for line in infile:
             progress.update(len(line))
             line_count += 1
@@ -1037,7 +1037,7 @@ def conversations(
     count = 0
     stop = False
 
-    with FileSizeProgressBar(infile, disable=hide_progress) as progress:
+    with FileSizeProgressBar(infile, outfile, disable=hide_progress) as progress:
         for line in infile:
             progress.update(len(line))
             conv_ids = []
@@ -1114,7 +1114,7 @@ def flatten(infile, outfile, hide_progress):
         )
         return
 
-    with FileSizeProgressBar(infile, disable=hide_progress) as progress:
+    with FileSizeProgressBar(infile, outfile, disable=hide_progress) as progress:
         for line in infile:
             for tweet in ensure_flattened(json.loads(line)):
                 _write(tweet, outfile, False)

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -401,7 +401,7 @@ def tweet(T, tweet_id, outfile, pretty):
     "--hide-progress",
     is_flag=True,
     default=False,
-    help="Hide the Progress bar. Default: show progress, unless using pipes.",
+    help="Hide the Progress bar. Default: show progress",
 )
 @click.argument("user", type=str)
 @click.argument("outfile", type=click.File("w"), default="-")
@@ -437,7 +437,7 @@ def followers(T, user, outfile, limit, hide_progress):
     "--hide-progress",
     is_flag=True,
     default=False,
-    help="Hide the Progress bar. Default: show progress, unless using pipes.",
+    help="Hide the Progress bar. Default: show progress",
 )
 @click.argument("user", type=str)
 @click.argument("outfile", type=click.File("w"), default="-")

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -14,6 +14,7 @@ import requests
 import configobj
 import threading
 
+from tqdm import tqdm
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 
@@ -189,9 +190,11 @@ def search(T, query, outfile, since_id, until_id, start_time, end_time, limit,
             max_results = 100
         search_method = T.search_recent
 
+    pbar = _id_progress_bar(since_id, until_id, start_time, end_time)
     for result in search_method(query, since_id, until_id, start_time, end_time,
             max_results):
         _write(result, outfile)
+        pbar.update(int(result["meta"]["newest_id"]) - pbar.n)
         count += len(result['data'])
         if limit != 0 and count >= limit:
             break
@@ -658,6 +661,17 @@ def delete_all(T):
         results = T.delete_stream_rule_ids(rule_ids)
         click.echo(f"🗑  Deleted {len(rule_ids)} rules.")
 
+
+def _id_progress_bar():
+    """
+    Snowflake ID based progress bar.
+    """
+    return tqdm(
+        total=1,
+        )
+
+def _date_to_snowflake(date):
+    return 1
 
 def _rule_str(rule):
     s = f"id={rule['id']} value={rule['value']}"

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -14,45 +14,82 @@ import requests
 import configobj
 import threading
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 
 from twarc.version import version
 from twarc.handshake import handshake
-from twarc.config import ConfigProvider 
-from twarc.decorators import cli_api_error
+from twarc.config import ConfigProvider
+from twarc.decorators import cli_api_error, prbar
 from twarc.expansions import ensure_flattened
 from click_config_file import configuration_option
 
 config_provider = ConfigProvider()
 
-@with_plugins(iter_entry_points('twarc.plugins'))
+
+@with_plugins(iter_entry_points("twarc.plugins"))
 @click.group()
-@click.option('--consumer-key', type=str, envvar='CONSUMER_KEY',
-    help='Twitter app consumer key (aka "App Key")')
-@click.option('--consumer-secret', type=str, envvar='CONSUMER_SECRET',
-    help='Twitter app consumer secret (aka "App Secret")')
-@click.option('--access-token', type=str, envvar='ACCESS_TOKEN',
-    help='Twitter app access token for user authentication.')
-@click.option('--access-token-secret', type=str, envvar='ACCESS_TOKEN_SECRET',
-    help='Twitter app access token secret for user authentication.')
-@click.option('--bearer-token', type=str, envvar='BEARER_TOKEN',
-    help='Twitter app access bearer token.')
-@click.option('--app-auth/--user-auth', default=True,
+@click.option(
+    "--consumer-key",
+    type=str,
+    envvar="CONSUMER_KEY",
+    help='Twitter app consumer key (aka "App Key")',
+)
+@click.option(
+    "--consumer-secret",
+    type=str,
+    envvar="CONSUMER_SECRET",
+    help='Twitter app consumer secret (aka "App Secret")',
+)
+@click.option(
+    "--access-token",
+    type=str,
+    envvar="ACCESS_TOKEN",
+    help="Twitter app access token for user authentication.",
+)
+@click.option(
+    "--access-token-secret",
+    type=str,
+    envvar="ACCESS_TOKEN_SECRET",
+    help="Twitter app access token secret for user authentication.",
+)
+@click.option(
+    "--bearer-token",
+    type=str,
+    envvar="BEARER_TOKEN",
+    help="Twitter app access bearer token.",
+)
+@click.option(
+    "--app-auth/--user-auth",
+    default=True,
     help="Use application authentication or user authentication. Some rate limits are "
     "higher with user authentication, but not all endpoints are supported.",
     show_default=True,
 )
-@click.option('--log', default='twarc.log')
-@click.option('--verbose', is_flag=True, default=False)
-@click.option('--metadata/--no-metadata', default=True, show_default=True,
-    help="Include/don't include metadata about when and how data was collected.")
-@configuration_option(cmd_name='twarc', config_file_name='config', provider=config_provider)
+@click.option("--log", default="twarc.log")
+@click.option("--verbose", is_flag=True, default=False)
+@click.option(
+    "--metadata/--no-metadata",
+    default=True,
+    show_default=True,
+    help="Include/don't include metadata about when and how data was collected.",
+)
+@configuration_option(
+    cmd_name="twarc", config_file_name="config", provider=config_provider
+)
 @click.pass_context
 def twarc2(
-    ctx, consumer_key, consumer_secret, access_token, access_token_secret, bearer_token,
-    log, metadata, app_auth, verbose
+    ctx,
+    consumer_key,
+    consumer_secret,
+    access_token,
+    access_token_secret,
+    bearer_token,
+    log,
+    metadata,
+    app_auth,
+    verbose,
 ):
     """
     Collect data from the Twitter V2 API.
@@ -60,7 +97,7 @@ def twarc2(
     logging.basicConfig(
         filename=log,
         level=logging.DEBUG if verbose else logging.INFO,
-        format="%(asctime)s %(levelname)s %(message)s"
+        format="%(asctime)s %(levelname)s %(message)s",
     )
 
     logging.info("using config %s", config_provider.file_path)
@@ -68,26 +105,31 @@ def twarc2(
     if bearer_token or (consumer_key and consumer_secret):
         if app_auth and (bearer_token or (consumer_key and consumer_secret)):
             ctx.obj = twarc.Twarc2(
-                consumer_key=consumer_key, consumer_secret=consumer_secret,
-                bearer_token=bearer_token, metadata=metadata
+                consumer_key=consumer_key,
+                consumer_secret=consumer_secret,
+                bearer_token=bearer_token,
+                metadata=metadata,
             )
         # Check everything is present for user auth.
-        elif (consumer_key and consumer_secret and access_token and access_token_secret):
+        elif consumer_key and consumer_secret and access_token and access_token_secret:
             ctx.obj = twarc.Twarc2(
-                consumer_key=consumer_key, consumer_secret=consumer_secret,
-                access_token=access_token, access_token_secret=access_token_secret,
-                metadata=metadata
+                consumer_key=consumer_key,
+                consumer_secret=consumer_secret,
+                access_token=access_token,
+                access_token_secret=access_token_secret,
+                metadata=metadata,
             )
         else:
             click.echo(
                 click.style(
-                    '🙃  To use user authentication, you need all of the following:\n'
-                    '- consumer_key\n',
-                    '- consumer_secret\n',
-                    '- access_token\n',
-                    '- access_token_secret\n',
-                     fg='red'),
-                err=True
+                    "🙃  To use user authentication, you need all of the following:\n"
+                    "- consumer_key\n",
+                    "- consumer_secret\n",
+                    "- access_token\n",
+                    "- access_token_secret\n",
+                    fg="red",
+                ),
+                err=True,
             )
             click.echo("You can configure twarc2 using the `twarc2 configure` command.")
     else:
@@ -103,7 +145,7 @@ def twarc2(
         ctx.invoke(configure)
 
 
-@twarc2.command('configure')
+@twarc2.command("configure")
 @click.pass_context
 def configure(ctx):
     """
@@ -111,13 +153,13 @@ def configure(ctx):
     """
 
     config_file = config_provider.file_path
-    logging.info('creating config file: %s', config_file)
+    logging.info("creating config file: %s", config_file)
 
     config_dir = pathlib.Path(config_file).parent
     if not config_dir.is_dir():
-        logging.info('creating config directory: %s', config_dir)
+        logging.info("creating config directory: %s", config_dir)
         config_dir.mkdir(parents=True)
- 
+
     keys = handshake()
     if keys is None:
         raise click.ClickException("Unable to authenticate")
@@ -131,49 +173,71 @@ def configure(ctx):
         "consumer_secret",
         "access_token",
         "access_token_secret",
-        "bearer_token"
+        "bearer_token",
     ]:
         if keys.get(key, None):
             config[key] = keys[key]
 
     config.write()
 
-    click.echo(click.style(f'\nYour keys have been written to {config_file}', fg='green'))
+    click.echo(
+        click.style(f"\nYour keys have been written to {config_file}", fg="green")
+    )
     click.echo()
-    click.echo('\n✨ ✨ ✨  Happy twarcing! ✨ ✨ ✨\n')
+    click.echo("\n✨ ✨ ✨  Happy twarcing! ✨ ✨ ✨\n")
 
     ctx.exit()
 
 
-@twarc2.command('version')
+@twarc2.command("version")
 def get_version():
     """
     Return the version of twarc that is installed.
     """
-    click.echo(f'twarc v{version}')
+    click.echo(f"twarc v{version}")
 
 
-@twarc2.command('search')
-@click.option('--since-id', type=int,
-    help='Match tweets sent after tweet id')
-@click.option('--until-id', type=int,
-    help='Match tweets sent prior to tweet id')
-@click.option('--start-time',
-    type=click.DateTime(formats=('%Y-%m-%d', '%Y-%m-%dT%H:%M:%S')),
-    help='Match tweets created after UTC time (ISO 8601/RFC 3339), e.g.  2021-01-01T12:31:04')
-@click.option('--end-time',
-    type=click.DateTime(formats=('%Y-%m-%d', '%Y-%m-%dT%H:%M:%S')),
-    help='Match tweets sent before UTC time (ISO 8601/RFC 3339)')
-@click.option('--archive', is_flag=True, default=False,
-    help='Search the full archive (requires Academic Research track)')
-@click.option('--limit', default=0, help='Maximum number of tweets to save')
-@click.option('--max-results', default=0, help='Maximum number of tweets per API response')
-@click.argument('query', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("search")
+@click.option("--since-id", type=int, help="Match tweets sent after tweet id")
+@click.option("--until-id", type=int, help="Match tweets sent prior to tweet id")
+@click.option(
+    "--start-time",
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S")),
+    help="Match tweets created after UTC time (ISO 8601/RFC 3339), e.g.  2021-01-01T12:31:04",
+)
+@click.option(
+    "--end-time",
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S")),
+    help="Match tweets sent before UTC time (ISO 8601/RFC 3339)",
+)
+@click.option(
+    "--archive",
+    is_flag=True,
+    default=False,
+    help="Search the full archive (requires Academic Research track)",
+)
+@click.option("--limit", default=0, help="Maximum number of tweets to save")
+@click.option(
+    "--max-results", default=0, help="Maximum number of tweets per API response"
+)
+@click.argument("query", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
-def search(T, query, outfile, since_id, until_id, start_time, end_time, limit,
-        max_results, archive):
+@prbar
+def search(
+    T,
+    query,
+    outfile,
+    since_id,
+    until_id,
+    start_time,
+    end_time,
+    limit,
+    max_results,
+    archive,
+    **kwargs,
+):
     """
     Search for tweets.
     """
@@ -190,38 +254,50 @@ def search(T, query, outfile, since_id, until_id, start_time, end_time, limit,
             max_results = 100
         search_method = T.search_recent
 
-    pbar = _id_progress_bar(since_id, until_id, start_time, end_time)
-    for result in search_method(query, since_id, until_id, start_time, end_time,
-            max_results):
-        _write(result, outfile)
-        pbar.update(int(result["meta"]["newest_id"]) - pbar.n)
-        count += len(result['data'])
-        if limit != 0 and count >= limit:
-            break
+    pbar = kwargs["progress_bar"]
 
-@twarc2.command('tweet')
-@click.option('--pretty', is_flag=True, default=False,
-    help='Pretty print the JSON')
-@click.argument('tweet_id', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+    for result in search_method(
+        query, since_id, until_id, start_time, end_time, max_results
+    ):
+        _write(result, outfile)
+
+        if kwargs.get("progress_bar"):
+            # print("Progress bar exists!")
+            pbar.update_ids(result["meta"])
+
+        count += len(result["data"])
+        if limit != 0 and count >= limit:
+            pbar.desc = f"--limit {limit} reached"
+            break
+    else:
+        print("Finishing")
+        pbar.update(pbar.total - pbar.n)
+
+    pbar.close()
+
+
+@twarc2.command("tweet")
+@click.option("--pretty", is_flag=True, default=False, help="Pretty print the JSON")
+@click.argument("tweet_id", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def tweet(T, tweet_id, outfile, pretty):
     """
     Look up a tweet using its tweet id or URL.
     """
-    if 'https' in tweet_id:
-        tweet_id = url_or_id.split('/')[-1]
-    if not re.match('^\d+$', tweet_id):
+    if "https" in tweet_id:
+        tweet_id = url_or_id.split("/")[-1]
+    if not re.match("^\d+$", tweet_id):
         click.echo(click.style("Please enter a tweet URL or ID", fg="red"), err=True)
     result = next(T.tweet_lookup([tweet_id]))
     _write(result, outfile, pretty=pretty)
 
 
-@twarc2.command('followers')
-@click.option('--limit', default=0, help='Maximum number of followers to save')
-@click.argument('user', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("followers")
+@click.option("--limit", default=0, help="Maximum number of followers to save")
+@click.argument("user", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def followers(T, user, outfile, limit):
@@ -232,15 +308,15 @@ def followers(T, user, outfile, limit):
 
     for result in T.followers(user):
         _write(result, outfile)
-        count += len(result['data'])
+        count += len(result["data"])
         if limit != 0 and count >= limit:
             break
 
 
-@twarc2.command('following')
-@click.option('--limit', default=0, help='Maximum number of friends to save')
-@click.argument('userd', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("following")
+@click.option("--limit", default=0, help="Maximum number of friends to save")
+@click.argument("userd", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def following(T, user, outfile, limit):
@@ -251,14 +327,14 @@ def following(T, user, outfile, limit):
 
     for result in T.following(user):
         _write(result, outfile)
-        count += len(result['data'])
+        count += len(result["data"])
         if limit != 0 and count >= limit:
             break
 
 
-@twarc2.command('sample')
-@click.option('--limit', default=0, help='Maximum number of tweets to save')
-@click.argument('outfile', type=click.File('a+'), default='-')
+@twarc2.command("sample")
+@click.option("--limit", default=0, help="Maximum number of tweets to save")
+@click.argument("outfile", type=click.File("a+"), default="-")
 @click.pass_obj
 @cli_api_error
 def sample(T, outfile, limit):
@@ -267,7 +343,12 @@ def sample(T, outfile, limit):
     """
     count = 0
     event = threading.Event()
-    click.echo(click.style(f'Started a random sample stream, writing to {outfile.name}\nCTRL+C to stop...', fg='green'))
+    click.echo(
+        click.style(
+            f"Started a random sample stream, writing to {outfile.name}\nCTRL+C to stop...",
+            fg="green",
+        )
+    )
     for result in T.sample(event=event):
         count += 1
         if limit != 0 and count >= limit:
@@ -275,9 +356,9 @@ def sample(T, outfile, limit):
         _write(result, outfile)
 
 
-@twarc2.command('hydrate')
-@click.argument('infile', type=click.File('r'), default='-')
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("hydrate")
+@click.argument("infile", type=click.File("r"), default="-")
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def hydrate(T, infile, outfile):
@@ -288,10 +369,10 @@ def hydrate(T, infile, outfile):
         _write(result, outfile)
 
 
-@twarc2.command('users')
-@click.option('--usernames', is_flag=True, default=False)
-@click.argument('infile', type=click.File('r'), default='-')
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("users")
+@click.option("--usernames", is_flag=True, default=False)
+@click.argument("infile", type=click.File("r"), default="-")
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def users(T, infile, outfile, usernames):
@@ -302,19 +383,21 @@ def users(T, infile, outfile, usernames):
         _write(result, outfile)
 
 
-@twarc2.command('mentions')
-@click.option('--since-id', type=int,
-    help='Match tweets sent after tweet id')
-@click.option('--until-id', type=int,
-    help='Match tweets sent prior to tweet id')
-@click.option('--start-time',
-    type=click.DateTime(formats=('%Y-%m-%d', '%Y-%m-%dT%H:%M:%S')),
-    help='Match tweets created after time (ISO 8601/RFC 3339), e.g.  2021-01-01T12:31:04')
-@click.option('--end-time',
-    type=click.DateTime(formats=('%Y-%m-%d', '%Y-%m-%dT%H:%M:%S')),
-    help='Match tweets sent before time (ISO 8601/RFC 3339)')
-@click.argument('user_id', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("mentions")
+@click.option("--since-id", type=int, help="Match tweets sent after tweet id")
+@click.option("--until-id", type=int, help="Match tweets sent prior to tweet id")
+@click.option(
+    "--start-time",
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S")),
+    help="Match tweets created after time (ISO 8601/RFC 3339), e.g.  2021-01-01T12:31:04",
+)
+@click.option(
+    "--end-time",
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S")),
+    help="Match tweets sent before time (ISO 8601/RFC 3339)",
+)
+@click.argument("user_id", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def mentions(T, user_id, outfile, since_id, until_id, start_time, end_time):
@@ -325,32 +408,39 @@ def mentions(T, user_id, outfile, since_id, until_id, start_time, end_time):
         _write(result, outfile)
 
 
-@twarc2.command('timeline')
-@click.option('--limit', default=0, help='Maximum number of tweets to return')
-@click.option('--since-id', type=int,
-    help='Match tweets sent after tweet id')
-@click.option('--until-id', type=int,
-    help='Match tweets sent prior to tweet id')
-@click.option('--start-time',
-    type=click.DateTime(formats=('%Y-%m-%d', '%Y-%m-%dT%H:%M:%S')),
-    help='Match tweets created after time (ISO 8601/RFC 3339), e.g.  2021-01-01T12:31:04')
-@click.option('--end-time',
-    type=click.DateTime(formats=('%Y-%m-%d', '%Y-%m-%dT%H:%M:%S')),
-    help='Match tweets sent before time (ISO 8601/RFC 3339)')
-@click.option('--use-search', is_flag=True, default=False,
-    help='Use the search/all API endpoint which is not limited to the last 3200 tweets, but requires Academic Product Track access.')
-@click.argument('user_id', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("timeline")
+@click.option("--limit", default=0, help="Maximum number of tweets to return")
+@click.option("--since-id", type=int, help="Match tweets sent after tweet id")
+@click.option("--until-id", type=int, help="Match tweets sent prior to tweet id")
+@click.option(
+    "--start-time",
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S")),
+    help="Match tweets created after time (ISO 8601/RFC 3339), e.g.  2021-01-01T12:31:04",
+)
+@click.option(
+    "--end-time",
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S")),
+    help="Match tweets sent before time (ISO 8601/RFC 3339)",
+)
+@click.option(
+    "--use-search",
+    is_flag=True,
+    default=False,
+    help="Use the search/all API endpoint which is not limited to the last 3200 tweets, but requires Academic Product Track access.",
+)
+@click.argument("user_id", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
-def timeline(T, user_id, outfile, since_id, until_id, start_time, end_time,
-        use_search, limit):
+def timeline(
+    T, user_id, outfile, since_id, until_id, start_time, end_time, use_search, limit
+):
     """
     Retrieve recent tweets for the given user.
     """
 
     if use_search:
-        q = f'from:{user_id}'
+        q = f"from:{user_id}"
         tweets = T.search_all(q, since_id, until_id, start_time, end_time)
     else:
         tweets = T.timeline(user_id, since_id, until_id, start_time, end_time)
@@ -359,24 +449,31 @@ def timeline(T, user_id, outfile, since_id, until_id, start_time, end_time,
     for result in tweets:
         _write(result, outfile)
 
-        count += len(result['data'])
+        count += len(result["data"])
         if limit != 0 and count >= limit:
             break
 
 
-@twarc2.command('timelines')
-@click.option('--limit', default=0, help='Maximum number of tweets to return')
-@click.option('--timeline-limit', default=0,
-    help='Maximum number of tweets to return per-timeline')
-@click.option('--use-search', is_flag=True, default=False,
-    help='Use the search/all API endpoint which is not limited to the last 3200 tweets, but requires Academic Product Track access.')
-@click.argument('infile', type=click.File('r'), default='-')
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("timelines")
+@click.option("--limit", default=0, help="Maximum number of tweets to return")
+@click.option(
+    "--timeline-limit",
+    default=0,
+    help="Maximum number of tweets to return per-timeline",
+)
+@click.option(
+    "--use-search",
+    is_flag=True,
+    default=False,
+    help="Use the search/all API endpoint which is not limited to the last 3200 tweets, but requires Academic Product Track access.",
+)
+@click.argument("infile", type=click.File("r"), default="-")
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 def timelines(T, infile, outfile, limit, timeline_limit, use_search):
     """
     Fetch the timelines of every user in an input source of tweets. If
-    the input is a line oriented text file of user ids or usernames that will 
+    the input is a line oriented text file of user ids or usernames that will
     be used instead.
     """
     total_count = 0
@@ -389,7 +486,7 @@ def timelines(T, infile, outfile, limit, timeline_limit, use_search):
         users = []
         try:
             data = ensure_flattened(json.loads(line))
-            users = set([t['author']['id'] for t in ensure_flattened(data)])
+            users = set([t["author"]["id"] for t in ensure_flattened(data)])
         except json.JSONDecodeError:
             users = set([line])
         except ValueError:
@@ -404,9 +501,9 @@ def timelines(T, infile, outfile, limit, timeline_limit, use_search):
 
             # which api endpoint to use
             if use_search and since_id:
-                tweets = T.search_all(f'from:{user}', since_id=since_id)
+                tweets = T.search_all(f"from:{user}", since_id=since_id)
             elif use_search:
-                tweets = T.search_all(f'from:{user}')
+                tweets = T.search_all(f"from:{user}")
             else:
                 tweets = T.timeline(user)
 
@@ -414,27 +511,31 @@ def timelines(T, infile, outfile, limit, timeline_limit, use_search):
             for response in tweets:
                 _write(response, outfile)
 
-                timeline_count += len(response['data'])
+                timeline_count += len(response["data"])
                 if timeline_limit != 0 and timeline_count >= timeline_limit:
                     break
 
-                total_count += len(response['data'])
+                total_count += len(response["data"])
                 if limit != 0 and total_count >= limit:
                     return
 
 
-@twarc2.command('conversation')
-@click.option('--archive', is_flag=True, default=False,
-    help='Search the full archive (requires Academic Research track)')
-@click.argument('tweet_id', type=str)
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("conversation")
+@click.option(
+    "--archive",
+    is_flag=True,
+    default=False,
+    help="Search the full archive (requires Academic Research track)",
+)
+@click.argument("tweet_id", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def conversation(T, tweet_id, archive, outfile):
     """
     Retrieve a conversation thread using the tweet id.
     """
-    q = f'conversation_id:{tweet_id}'
+    q = f"conversation_id:{tweet_id}"
     if archive:
         search = T.search_all(q)
     else:
@@ -443,14 +544,21 @@ def conversation(T, tweet_id, archive, outfile):
         _write(resp, outfile)
 
 
-@twarc2.command('conversations')
-@click.option('--limit', default=0, help='Maximum number of tweets to return')
-@click.option('--conversation-limit', default=0,
-    help='Maximum number of tweets to return per-conversation')
-@click.option('--archive', is_flag=True, default=False,
-    help='Use the Academic Research project track access to the full archive')
-@click.argument('infile', type=click.File('r'), default='-')
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("conversations")
+@click.option("--limit", default=0, help="Maximum number of tweets to return")
+@click.option(
+    "--conversation-limit",
+    default=0,
+    help="Maximum number of tweets to return per-conversation",
+)
+@click.option(
+    "--archive",
+    is_flag=True,
+    default=False,
+    help="Use the Academic Research project track access to the full archive",
+)
+@click.argument("infile", type=click.File("r"), default="-")
+@click.argument("outfile", type=click.File("w"), default="-")
 @click.pass_obj
 @cli_api_error
 def conversations(T, infile, outfile, archive, limit, conversation_limit):
@@ -477,16 +585,18 @@ def conversations(T, infile, outfile, archive, limit, conversation_limit):
 
         # get a specific conversation id
         line = line.strip()
-        if re.match(r'^\d+$', line):
+        if re.match(r"^\d+$", line):
             if line in seen:
                 continue
             conv_ids = [line]
 
         # generate all conversation_ids that are referenced in tweets input
         else:
+
             def f():
                 for tweet in ensure_flattened(json.loads(line)):
-                    yield tweet.get('conversation_id')
+                    yield tweet.get("conversation_id")
+
             conv_ids = f()
 
         # output results while paying attention to the set limits
@@ -495,38 +605,44 @@ def conversations(T, infile, outfile, archive, limit, conversation_limit):
         for conv_id in conv_ids:
 
             if conv_id in seen:
-                logging.info(f'already fetched conversation_id {conv_id}')
+                logging.info(f"already fetched conversation_id {conv_id}")
             seen.add(conv_id)
 
             conv_count = 0
 
-            logging.info(f'fetching conversation {conv_id}')
-            for result in search(f'conversation_id:{conv_id}'): 
+            logging.info(f"fetching conversation {conv_id}")
+            for result in search(f"conversation_id:{conv_id}"):
                 _write(result, outfile, False)
 
-                count += len(result['data'])
+                count += len(result["data"])
                 if limit != 0 and count >= limit:
-                    logging.info(f'reached tweet limit of {limit}')
+                    logging.info(f"reached tweet limit of {limit}")
                     stop = True
                     break
 
-                conv_count += len(result['data'])
-                if conversation_limit !=0 and conv_count >= conversation_limit:
-                    logging.info(f'reached conversation limit {conversation_limit}')
+                conv_count += len(result["data"])
+                if conversation_limit != 0 and conv_count >= conversation_limit:
+                    logging.info(f"reached conversation limit {conversation_limit}")
                     break
 
 
-@twarc2.command('flatten')
-@click.argument('infile', type=click.File('r'), default='-')
-@click.argument('outfile', type=click.File('w'), default='-')
+@twarc2.command("flatten")
+@click.argument("infile", type=click.File("r"), default="-")
+@click.argument("outfile", type=click.File("w"), default="-")
 @cli_api_error
 def flatten(infile, outfile):
     """
     "Flatten" tweets, or move expansions inline with tweet objects and ensure
     that each line of output is a single tweet.
     """
-    if (infile.name == outfile.name):
-        click.echo(click.style(f"💔 Cannot flatten files in-place, specify a different output file!", fg='red'), err=True)
+    if infile.name == outfile.name:
+        click.echo(
+            click.style(
+                f"💔 Cannot flatten files in-place, specify a different output file!",
+                fg="red",
+            ),
+            err=True,
+        )
         return
 
     for line in infile:
@@ -534,9 +650,9 @@ def flatten(infile, outfile):
             _write(tweet, outfile, False)
 
 
-@twarc2.command('stream')
-@click.option('--limit', default=0, help='Maximum number of tweets to return')
-@click.argument('outfile', type=click.File('a+'), default='-')
+@twarc2.command("stream")
+@click.option("--limit", default=0, help="Maximum number of tweets to return")
+@click.argument("outfile", type=click.File("a+"), default="-")
 @click.pass_obj
 @cli_api_error
 def stream(T, outfile, limit):
@@ -545,15 +661,16 @@ def stream(T, outfile, limit):
     """
     event = threading.Event()
     count = 0
-    click.echo(click.style(f'Started a stream with rules:', fg='green'),
-            err=True)
+    click.echo(click.style(f"Started a stream with rules:", fg="green"), err=True)
     _print_stream_rules(T)
-    click.echo(click.style(f'Writing to {outfile.name}\nCTRL+C to stop...',
-        fg='green'), err=True)
+    click.echo(
+        click.style(f"Writing to {outfile.name}\nCTRL+C to stop...", fg="green"),
+        err=True,
+    )
     for result in T.stream(event=event):
         count += 1
         if limit != 0 and count == limit:
-            logging.info(f'reached limit {limit}')
+            logging.info(f"reached limit {limit}")
             event.set()
         _write(result, outfile)
 
@@ -567,7 +684,7 @@ def stream_rules(T):
     pass
 
 
-@stream_rules.command('list')
+@stream_rules.command("list")
 @click.pass_obj
 @cli_api_error
 def list_stream_rules(T):
@@ -576,29 +693,34 @@ def list_stream_rules(T):
     """
     _print_stream_rules(T)
 
+
 def _print_stream_rules(T):
     """
     Output all the active stream rules
     """
     result = T.get_stream_rules()
-    if 'data' not in result or len(result['data']) == 0:
-        click.echo('No rules yet. Add them with ' + click.style('twarc2 stream-rules add', bold=True), err=True)
+    if "data" not in result or len(result["data"]) == 0:
+        click.echo(
+            "No rules yet. Add them with "
+            + click.style("twarc2 stream-rules add", bold=True),
+            err=True,
+        )
     else:
         count = 0
-        for rule in result['data']:
+        for rule in result["data"]:
             if count > 5:
                 count = 0
-            s = rule['value']
-            if 'tag' in rule:
+            s = rule["value"]
+            if "tag" in rule:
                 s += f" (tag: {rule['tag']})"
-            click.echo(click.style(f'☑  {s}'), err=True)
+            click.echo(click.style(f"☑  {s}"), err=True)
             count += 1
 
 
-@stream_rules.command('add')
+@stream_rules.command("add")
 @click.pass_obj
-@click.option('--tag', type=str, help='a tag to help identify the rule')
-@click.argument('value', type=str)
+@click.option("--tag", type=str, help="a tag to help identify the rule")
+@click.argument("value", type=str)
 @cli_api_error
 def add_stream_rule(T, value, tag):
     """
@@ -611,14 +733,14 @@ def add_stream_rule(T, value, tag):
         rules = [{"value": value}]
 
     results = T.add_stream_rules(rules)
-    if 'errors' in results:
-        click.echo(_error_str(results['errors']), err=True)
+    if "errors" in results:
+        click.echo(_error_str(results["errors"]), err=True)
     else:
-        click.echo(click.style(f'🚀  Added rule for ', fg='green') + f'"{value}"')
+        click.echo(click.style(f"🚀  Added rule for ", fg="green") + f'"{value}"')
 
 
-@stream_rules.command('delete')
-@click.argument('value')
+@stream_rules.command("delete")
+@click.argument("value")
 @click.pass_obj
 @cli_api_error
 def delete_stream_rule(T, value):
@@ -627,26 +749,28 @@ def delete_stream_rule(T, value):
     """
     # find the rule id
     result = T.get_stream_rules()
-    if 'data' not in result:
-        click.echo(click.style('💔  There are no rules to delete!', fg='red'), err=True)
+    if "data" not in result:
+        click.echo(click.style("💔  There are no rules to delete!", fg="red"), err=True)
     else:
         rule_id = None
-        for rule in result['data']:
-            if rule['value'] == value:
-                rule_id = rule['id']
+        for rule in result["data"]:
+            if rule["value"] == value:
+                rule_id = rule["id"]
                 break
         if not rule_id:
-            click.echo(click.style(f'🙃  No rule could be found for "{value}"',
-                fg='red'), err=True)
+            click.echo(
+                click.style(f'🙃  No rule could be found for "{value}"', fg="red"),
+                err=True,
+            )
         else:
             results = T.delete_stream_rule_ids([rule_id])
-            if 'errors' in results:
-                click.echo(_error_str(results['errors']), err=True)
+            if "errors" in results:
+                click.echo(_error_str(results["errors"]), err=True)
             else:
-                click.echo(f"🗑  Deleted stream rule for {value}", color='green')
+                click.echo(f"🗑  Deleted stream rule for {value}", color="green")
 
 
-@stream_rules.command('delete-all')
+@stream_rules.command("delete-all")
 @click.pass_obj
 @cli_api_error
 def delete_all(T):
@@ -654,28 +778,17 @@ def delete_all(T):
     Delete all stream rules!
     """
     result = T.get_stream_rules()
-    if 'data' not in result:
-        click.echo(click.style('💔  There are no rules to delete!', fg='red'), err=True)
+    if "data" not in result:
+        click.echo(click.style("💔  There are no rules to delete!", fg="red"), err=True)
     else:
-        rule_ids = [r['id'] for r in result['data']]
+        rule_ids = [r["id"] for r in result["data"]]
         results = T.delete_stream_rule_ids(rule_ids)
         click.echo(f"🗑  Deleted {len(rule_ids)} rules.")
 
 
-def _id_progress_bar(since_id, until_id, start_time, end_time):
-    """
-    Snowflake ID based progress bar.
-    """
-    return tqdm(
-        total=1,
-        )
-
-def _date_to_snowflake(date):
-    return 1
-
 def _rule_str(rule):
     s = f"id={rule['id']} value={rule['value']}"
-    if 'tag' in rule:
+    if "tag" in rule:
         s += f" tag={rule['tag']}"
     return s
 
@@ -690,19 +803,20 @@ def _error_str(errors):
 
     parts = []
     for error in errors:
-        for part in error['errors']:
+        for part in error["errors"]:
             s = "💣  "
-            if 'message' in part:
-                s += click.style(part['message'], fg='red')
-            elif 'title' in part:
-                s += click.style(part['title'], fg='red')
+            if "message" in part:
+                s += click.style(part["message"], fg="red")
+            elif "title" in part:
+                s += click.style(part["title"], fg="red")
             else:
-                s = click.style('Unknown error', fg='red')
-            if 'type' in part:
+                s = click.style("Unknown error", fg="red")
+            if "type" in part:
                 s += f" see: {part['type']}"
             parts.append(s)
 
     return click.style("\n".join(parts), fg="red")
+
 
 def _write(results, outfile, pretty=False):
     indent = 2 if pretty else None

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -232,6 +232,7 @@ def _search(
     hide_progress = True if (outfile.name == "<stdout>") else hide_progress
 
     if not hide_progress:
+
         try:
             # Single request just for the total
             count_lookup = next(
@@ -239,7 +240,7 @@ def _search(
             )
             lookup_total = count_lookup["meta"]["total_tweet_count"]
         except Exception as e:
-            log.error("Failed getting counts:", e)
+            log.error(f"Failed getting counts: {str(e)}")
             click.echo(
                 click.style(
                     f"Failed to get counts, progress bar will not work, but continuing to search. Check twarc.log for errors.",

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -575,7 +575,7 @@ def users(T, infile, outfile, usernames, hide_progress):
     "--hide-progress",
     is_flag=True,
     default=False,
-    help="Hide the Progress bar. Default: show progress, unless using pipes.",
+    help="Hide the Progress bar. Default: show progress",
 )
 @click.argument("user_id", type=str)
 @click.argument("outfile", type=click.File("w"), default="-")
@@ -585,10 +585,13 @@ def mentions(
     T, user_id, outfile, since_id, until_id, start_time, end_time, hide_progress
 ):
     """
-    Retrieve the most recent tweets mentioning the given user.
+    Retrieve max of 800 of the most recent tweets mentioning the given user.
     """
-    for result in T.mentions(user_id, since_id, until_id, start_time, end_time):
-        _write(result, outfile)
+
+    with tqdm(disable=hide_progress, total=800) as progress:
+        for result in T.mentions(user_id, since_id, until_id, start_time, end_time):
+            _write(result, outfile)
+            progress.update(len(result["data"]))
 
 
 @twarc2.command("timeline")

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -633,6 +633,12 @@ def mentions(
         for result in T.mentions(user_id, since_id, until_id, start_time, end_time):
             _write(result, outfile)
             progress.update(len(result["data"]))
+        else:
+            if progress.n > 800:
+                progress.desc = f"API limit reached with {progress.n} tweets"
+                progress.n = 800
+            else:
+                progress.desc = f"Set limit reached with {progress.n} tweets"
 
 
 @twarc2.command("timeline")

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -711,8 +711,12 @@ def timeline(
     count = 0
 
     pbar = tqdm
-    pbar_params = {"disable": hide_progress, "total": 3200}
+    user = T._ensure_user(user_id)
+    pbar_params = {"disable": hide_progress, "total": user["public_metrics"]["tweet_count"]}
+
     if use_search:
+        if start_time is None and since_id is None:
+            start_time = datetime.datetime.strptime(user["created_at"], '%Y-%m-%dT%H:%M:%S.%fZ')
         pbar = TimestampProgressBar
         pbar_params = {
             "since_id": since_id,
@@ -723,12 +727,11 @@ def timeline(
         }
 
     with pbar(**pbar_params) as progress:
-        
         for result in tweets:
             _write(result, outfile)
 
             count += len(result["data"])
-            if use_search and isinstance(pbar, TimestampProgressBar):
+            if use_search and isinstance(progress, TimestampProgressBar):
                 progress.update_with_result(result)
             else:
                 progress.update(len(result["data"]))
@@ -738,7 +741,7 @@ def timeline(
                 progress.desc = f"Set --limit of {limit} reached"
                 break
         else:
-            if isinstance(pbar, TimestampProgressBar):
+            if isinstance(progress, TimestampProgressBar):
                 progress.early_stop = False
 
 

--- a/twarc/decorators.py
+++ b/twarc/decorators.py
@@ -1,4 +1,3 @@
-import os
 import time
 import logging
 

--- a/twarc/decorators.py
+++ b/twarc/decorators.py
@@ -79,7 +79,7 @@ class TimestampProgressBar(tqdm):
         if start_time is None and since_id is None:
             start_time = datetime.datetime.now(
                 datetime.timezone.utc
-            ) - datetime.timedelta(seconds=90)
+            ) - datetime.timedelta(days=7)
         if end_time is None and until_id is None:
             end_time = datetime.datetime.now(
                 datetime.timezone.utc

--- a/twarc/decorators.py
+++ b/twarc/decorators.py
@@ -45,6 +45,7 @@ class TimestampProgressBar(tqdm):
         kwargs["miniters"] = 1
         kwargs["total"] = total
         kwargs["disable"] = disable
+        kwargs["bar_format"] = "{l_bar}{bar}| {total_time} [{elapsed}<{remaining}{postfix}]"
         super().__init__(**kwargs)
 
     def update_with_snowflake(self, newest_id, oldest_id):
@@ -56,10 +57,10 @@ class TimestampProgressBar(tqdm):
 
     @property
     def format_dict(self):
-        # Todo: Better Custom display
+        # Todo: Better Custom display, tweets / requests per second / output file size? 
         d = super(TimestampProgressBar, self).format_dict
         total_time = d["elapsed"] * (d["total"] or 0) / max(d["n"], 1)
-        d.update(total_time=self.format_interval(total_time) + " in total")
+        d.update(total_time=self.format_interval(total_time) + " elapsed")
         return d
 
     def close(self):

--- a/twarc/decorators.py
+++ b/twarc/decorators.py
@@ -27,18 +27,22 @@ class TimestampProgressBar(tqdm):
     def __init__(self, outfile, since_id, until_id, start_time, end_time, **kwargs):
 
         if start_time is None and since_id is None:
-        start_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=90
-        )
+            start_time = datetime.datetime.now(
+                datetime.timezone.utc
+            ) - datetime.timedelta(seconds=90)
         if end_time is None and until_id is None:
-            end_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-                seconds=30
-        )
+            end_time = datetime.datetime.now(
+                datetime.timezone.utc
+            ) - datetime.timedelta(seconds=30)
 
-        total = _snowflake2millis(until_id) - _snowflake2millis(since_id) if (since_id and until_id) else _date2millis(end_time) - _date2millis(start_time)
+        total = (
+            _snowflake2millis(until_id) - _snowflake2millis(since_id)
+            if (since_id and until_id)
+            else _date2millis(end_time) - _date2millis(start_time)
+        )
 
         kwargs["total"] = total
-        kwargs["disable"] = (outfile.name == "<stdout>")
+        kwargs["disable"] = outfile.name == "<stdout>"
         super().__init__(**kwargs)
 
     def update_with_snowflake(self, newest_id, oldest_id):

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -305,3 +305,20 @@ def _date2snowflake(dt):
 
 def _snowflake2date(snowflake_id):
     return _millis2date(_snowflake2millis(snowflake_id))
+
+
+def _time_delta(since_id, until_id, start_time, end_time):
+    if start_time is None and since_id is None:
+        start_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            days=7
+        )
+    if end_time is None and until_id is None:
+        end_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            seconds=30
+        )
+
+    if since_id and until_id:
+        start_time = _millis2date(_snowflake2millis(since_id))
+        end_time = _millis2date(_snowflake2millis(until_id))
+
+    return start_time - end_time

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -306,28 +306,3 @@ def _snowflake2millis(snowflake_id):
 
 def _millis2snowflake(ms):
     return (int(ms) - 1288834974657) << 22
-
-
-def _date2snowflake(dt):
-    return _millis2snowflake(_date2millis(dt))
-
-
-def _snowflake2date(snowflake_id):
-    return _millis2date(_snowflake2millis(snowflake_id))
-
-
-def _time_delta(since_id, until_id, start_time, end_time):
-    if start_time is None and since_id is None:
-        start_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            days=7
-        )
-    if end_time is None and until_id is None:
-        end_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=30
-        )
-
-    if since_id and until_id:
-        start_time = _millis2date(_snowflake2millis(since_id))
-        end_time = _millis2date(_snowflake2millis(until_id))
-
-    return start_time - end_time

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -227,7 +227,7 @@ class TimestampProgressBar(tqdm):
     """
 
     def __init__(self, since_id, until_id, start_time, end_time, **kwargs):
-        self.early_stop = False
+        self.early_stop = True
 
         disable = False if "disable" not in kwargs else kwargs["disable"]
         kwargs["disable"] = disable
@@ -263,6 +263,7 @@ class TimestampProgressBar(tqdm):
             oldest_id = result["meta"]["oldest_id"]
             n = _snowflake2millis(int(newest_id)) - _snowflake2millis(int(oldest_id))
             self.update(n)
+            early_stop = False
         except Exception as e:
             log.error(f"Failed to update progress bar: {e}")
 

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -266,7 +266,6 @@ class TimestampProgressBar(tqdm):
             n = _snowflake2millis(int(newest_id)) - _snowflake2millis(int(oldest_id))
             self.update(n)
             self.tweet_count += len(result["data"])
-            self.early_stop = False
         except Exception as e:
             log.error(f"Failed to update progress bar: {e}")
 

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -1,7 +1,6 @@
 import os
 import time
 import click
-import types
 import logging
 import requests
 
@@ -9,7 +8,6 @@ import datetime
 import humanize
 from tqdm.auto import tqdm
 from functools import wraps
-from collections import defaultdict
 
 
 log = logging.getLogger("twarc")

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -1,3 +1,4 @@
+import os
 import time
 import click
 import types

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -178,9 +178,11 @@ class FileSizeProgressBar(tqdm):
     Overrides `disable` parameter if file is a pipe.
     """
 
-    def __init__(self, infile, **kwargs):
+    def __init__(self, infile, outfile, **kwargs):
         disable = False if "disable" not in kwargs else kwargs["disable"]
         if infile is not None and (infile.name == "<stdin>"):
+            disable = True
+        if outfile is not None and (outfile.name == "<stdout>"):
             disable = True
         kwargs["disable"] = disable
         kwargs["unit"] = "B"
@@ -242,8 +244,10 @@ class TimestampProgressBar(tqdm):
             ) - datetime.timedelta(seconds=30)
 
         if since_id and not until_id:
-            until_id = _millis2snowflake(_date2millis(datetime.datetime.now(datetime.timezone.utc)))
-        
+            until_id = _millis2snowflake(
+                _date2millis(datetime.datetime.now(datetime.timezone.utc))
+            )
+
         if until_id and not since_id:
             since_id = 1
 

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -232,14 +232,20 @@ class TimestampProgressBar(tqdm):
         disable = False if "disable" not in kwargs else kwargs["disable"]
         kwargs["disable"] = disable
 
-        if start_time is None and since_id is None:
+        if start_time is None and (since_id is None and until_id is None):
             start_time = datetime.datetime.now(
                 datetime.timezone.utc
             ) - datetime.timedelta(days=7)
-        if end_time is None and until_id is None:
+        if end_time is None and (since_id is None and until_id is None):
             end_time = datetime.datetime.now(
                 datetime.timezone.utc
             ) - datetime.timedelta(seconds=30)
+
+        if since_id and not until_id:
+            until_id = _millis2snowflake(_date2millis(datetime.datetime.now(datetime.timezone.utc)))
+        
+        if until_id and not since_id:
+            since_id = 1
 
         total = (
             _snowflake2millis(until_id) - _snowflake2millis(since_id)

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -189,6 +189,9 @@ class FileSizeProgressBar(tqdm):
         kwargs["unit_scale"] = True
         kwargs["unit_divisor"] = 1024
         kwargs["miniters"] = 1
+        kwargs[
+            "bar_format"
+        ] = "{l_bar}{bar}| Processed {n_fmt}/{total_fmt} of input file [{elapsed}<{remaining}, {rate_fmt}{postfix}]"
         kwargs["total"] = os.stat(infile.name).st_size if not disable else 1
         super().__init__(**kwargs)
 


### PR DESCRIPTION
fixes #437, fixes #289

I think i got it to work how i wanted, but the missing part is a better display for the items /sec and current total. There's probably a better way of doing that that i'm still trying to figure out.

This only adds a progress bar to the search endpoint as an example - i'll add them to other commands if this one looks good.

Commands with progress bars:

- [x] search (snowflake timestamp)
- [x] flatten (input file)
- [x] users (input file)
- [x] hydrate (input file)
- [x] mentions (manual count - API limit of 800)
- [x] conversation (snowflake timestamp)
- [x] conversations (input file)
- [x] timeline (timestamp or manual count)
- [x] timelines (input file)
- [x] following (count using user lookup)
- [x] followers (count using user lookup)

Commands with `--limit` terminate the progress bar early - i think this is a good visual clue as to what's happening.