### PR TITLE
Flatten Refactor

### DIFF
--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -405,7 +405,7 @@ def test_flattened():
 
 
 def test_ensure_flattened():
-    resp = next(T.search_recent("twitter"))
+    resp = next(T.search_recent("twitter", max_results=20))
 
     # flatten a response
     flat1 = twarc.expansions.ensure_flattened(resp)
@@ -425,11 +425,11 @@ def test_ensure_flattened():
     assert len(flat3) == 1
 
     with pytest.raises(ValueError):
-        twarc.expansions.ensure_flattened({"fake": "tweet"})
+        twarc.expansions.ensure_flattened({"data": {"fake": "tweet"}})
     with pytest.raises(ValueError):
-        twarc.expansions.ensure_flattened([{"fake": "tweet"}])
+        twarc.expansions.ensure_flattened([{"data": {"fake": "tweet"}}])
     with pytest.raises(ValueError):
-        flat1[0].pop("author")
+        flat1[0].pop("includes")
         twarc.expansions.ensure_flattened(flat1)
 
 

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -451,7 +451,7 @@ def test_ensure_flattened():
     assert len(flat8) > 1
     # Flatten worked without includes, wrote empty object:
     assert "author" in flat8[0]
-    TestCase().assertDictEqual(flat8[0]['author'], {})
+    TestCase().assertDictEqual(flat8[0]["author"], {})
 
     # If there's some other type of data:
     with pytest.raises(ValueError):

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -424,13 +424,14 @@ def test_ensure_flattened():
     assert isinstance(flat3, list)
     assert len(flat3) == 1
 
+    # If there's "data" but no "includes":
     with pytest.raises(ValueError):
         twarc.expansions.ensure_flattened({"data": {"fake": "tweet"}})
     with pytest.raises(ValueError):
         twarc.expansions.ensure_flattened([{"data": {"fake": "tweet"}}])
     with pytest.raises(ValueError):
-        flat1[0].pop("includes")
-        twarc.expansions.ensure_flattened(flat1)
+        resp.pop("includes")
+        twarc.expansions.ensure_flattened(resp)
 
 
 def test_twarc_metadata():

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -430,7 +430,7 @@ def test_ensure_flattened():
     flat4 = twarc.expansions.ensure_flattened([{"data": {"fake": "tweet"}}])
     assert isinstance(flat4, list)
     assert len(flat4) == 1
-    # 1 records, data is a dict:
+    # 1 record, data is a dict:
     flat5 = twarc.expansions.ensure_flattened({"data": {"fake": "tweet"}})
     assert isinstance(flat5, list)
     assert len(flat5) == 1
@@ -453,7 +453,7 @@ def test_ensure_flattened():
     assert "author" in flat8[0]
     TestCase().assertDictEqual(flat8[0]['author'], {})
 
-    # If there's "some other type of data:
+    # If there's some other type of data:
     with pytest.raises(ValueError):
         twarc.expansions.ensure_flattened([[{"data": {"fake": "list_of_lists"}}]])
 

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -9,6 +9,8 @@ sure that data is flattened.
 
 from collections import defaultdict
 
+log = logging.getLogger("twarc")
+
 EXPANSIONS = [
     "author_id",
     "in_reply_to_user_id",
@@ -245,10 +247,8 @@ def ensure_flattened(data):
 
     # If it's a single response with data, but without includes:
     elif isinstance(data, dict) and "data" in data and "includes" not in data:
-        # Maybe this should be a warning instead? flatten() will still work, just with {}.
-        raise ValueError(
-            f"unable to expand tweet dictionary without original response data and includes: {data}"
-        )
+        # flatten() will still work, just with {} empty expansions.
+        log.warning(f"Unable to expand dictionary without includes: {data}")
 
     # If it's a single response and both "includes" and "data" are missing, it is already flattened
     elif isinstance(data, dict) and "data" not in data and "includes" not in data:
@@ -260,10 +260,8 @@ def ensure_flattened(data):
         if "data" in data[0] and "includes" in data[0]:
             return [flatten(item) for item in data]
         elif "data" in data[0] and "includes" not in data[0]:
-            # Again, maybe this should succeed with a warning?
-            raise ValueError(
-                f"unable to expand tweet dictionary without original response data and includes: {data[0]}"
-            )
+            # Log a warning because having databut no includes is still valid:
+            log.warning(f"Unable to expand dictionary without includes: {data[0]}")
         elif "data" not in data[0] and "includes" not in data[0]:
             return data
     else:

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -237,24 +237,15 @@ def ensure_flattened(data):
     processing applications that want to operate on a stream of tweets, and
     examine included entities like users and tweets without hunting and
     pecking in the response data.
-
-    Todo: make tests for:
-        - Single response
-        - List of responses
-        - Single tweet
-        - List of single tweets
-        - Single user object
-        - List of user objects
-        - Returns list of tweets
     """
 
-    # If it's a single response from the API, with data and includes, we can try to flatten it:
+    # If it's a single response from the API, with data and includes, we flatten it:
     if isinstance(data, dict) and "data" in data and "includes" in data:
         return flatten(data)
 
     # If it's a single response with data, but without includes:
     elif isinstance(data, dict) and "data" in data and "includes" not in data:
-        # flatten() will still work, just with {} empty expansions.
+        # flatten() will still work, just with {} empty expansions, log a warning.
         log.warning(f"Unable to expand dictionary without includes: {data}")
         return flatten(data)
 
@@ -264,14 +255,15 @@ def ensure_flattened(data):
 
     # If it's a list of objects (could be list of responses, or tweets, or users):
     elif isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
-        # Same as above, but flatten each object individually
+        # Same as above,
         if "data" in data[0] and "includes" in data[0]:
+            # but flatten each object individually and return a single list
             return list(chain.from_iterable([flatten(item) for item in data]))
         elif "data" in data[0] and "includes" not in data[0]:
-            # Log a warning because having databut no includes is still valid:
+            # same as above, log warnings and return a single list
             log.warning(f"Unable to expand dictionary without includes: {data[0]}")
             return list(chain.from_iterable([flatten(item) for item in data]))
-        # Already flattened
+        # Return already flattened data as is
         elif "data" not in data[0] and "includes" not in data[0]:
             return data
     # Unknown format, eg: list of lists, or primitive

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -7,6 +7,7 @@ ensure_flattened() can be used in tweet processing programs that need to make
 sure that data is flattened.
 """
 
+import logging
 from collections import defaultdict
 
 log = logging.getLogger("twarc")

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -250,6 +250,7 @@ def ensure_flattened(data):
     elif isinstance(data, dict) and "data" in data and "includes" not in data:
         # flatten() will still work, just with {} empty expansions.
         log.warning(f"Unable to expand dictionary without includes: {data}")
+        return flatten(data)
 
     # If it's a single response and both "includes" and "data" are missing, it is already flattened
     elif isinstance(data, dict) and "data" not in data and "includes" not in data:
@@ -263,7 +264,10 @@ def ensure_flattened(data):
         elif "data" in data[0] and "includes" not in data[0]:
             # Log a warning because having databut no includes is still valid:
             log.warning(f"Unable to expand dictionary without includes: {data[0]}")
+            return flatten(data)
+        # Already flattened
         elif "data" not in data[0] and "includes" not in data[0]:
             return data
+    # Unknown format, eg: list of lists, or primitive
     else:
         raise ValueError(f"Cannot flatten unrecognized data: {data}")


### PR DESCRIPTION
This is just missing some more tests. I changed the ensure_flatten function to hopefully be easier to understand and use. Before it would fail if presented with a list of user objects, because it relied on checking for `author` field - which won't exist in user objects.