### PR TITLE
improve v2 _ensure_user_id's handling of numeric screen names

### DIFF
--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -458,6 +458,26 @@ def test_ensure_flattened():
         twarc.expansions.ensure_flattened([[{"data": {"fake": "list_of_lists"}}]])
 
 
+def test_ensure_user_id():
+    """
+    Test _ensure_user_id's ability to discriminate correctly between IDs and
+    screen names.
+    """
+    # presumably IDs don't change
+    assert T._ensure_user_id("jack") == "12"
+
+    # should hold for all users, even if the screen name exists
+    assert T._ensure_user_id("12") == "12"
+
+    # this is a screen name but not an ID
+    # would help to find more "stable" example?
+    assert T._ensure_user_id("42069") == "17334495"
+    # should 42069 passed as int return ID or screen name?
+
+    assert T._ensure_user_id("1033441111677788160") == "1033441111677788160"
+    assert T._ensure_user_id(1033441111677788160) == "1033441111677788160"
+
+
 def test_twarc_metadata():
 
     # With metadata (default)

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -838,12 +838,26 @@ class Twarc2:
 
     def _ensure_user_id(self, user):
         user = str(user)
-        if re.match(r"^\d+$", user):
+        is_numeric = re.match(r"^\d+$", user)
+
+        def id_exists(user):
+            user_profile = next(self.user_lookup([user]))
+            try:
+                return all(
+                    error["title"] != "Not Found Error"
+                    for error in user_profile["errors"]
+                )
+            except KeyError:
+                return True
+
+        if len(user) > 15 or (is_numeric and id_exists(user)):
             return user
         else:
             results = next(self.user_lookup([user], usernames=True))
             if "data" in results and len(results["data"]) > 0:
                 return results["data"][0]["id"]
+            elif is_numeric:
+                return user
             else:
                 raise ValueError(f"No such user {user}")
 

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -841,11 +841,10 @@ class Twarc2:
         is_numeric = re.match(r"^\d+$", user)
 
         def id_exists(user):
-            user_profile = next(self.user_lookup([user]))
             try:
                 return all(
                     error["title"] != "Not Found Error"
-                    for error in user_profile["errors"]
+                    for error in next(self.user_lookup([user]))["errors"]
                 )
             except KeyError:
                 return True

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -842,10 +842,8 @@ class Twarc2:
 
         def id_exists(user):
             try:
-                return (
-                    next(self.user_lookup([user]))["errors"][0]["title"]
-                    != "Not Found Error"
-                )
+                error_name = next(self.user_lookup([user]))["errors"][0]["title"]
+                return error_name != "Not Found Error"
             except KeyError:
                 return True
 

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -842,9 +842,9 @@ class Twarc2:
 
         def id_exists(user):
             try:
-                return all(
-                    error["title"] != "Not Found Error"
-                    for error in next(self.user_lookup([user]))["errors"]
+                return (
+                    next(self.user_lookup([user]))["errors"][0]["title"]
+                    != "Not Found Error"
                 )
             except KeyError:
                 return True


### PR DESCRIPTION
_ensure_user_id currently returns any integer or numeric string unchanged, which means that any method that uses it will mishandle screen names that consist entirely of digits.

I changed its behavior in the case of a string that is a valid but nonexistent ID, but that _is_ an existent screen name. Otherwise nothing should have changed.

Some examples/test cases (is this too minor to add unit tests?):

```
In [3]: api._ensure_user_id("parafactual")
Out[3]: '1252277511746183168'

In [4]: api._ensure_user_id(Out[3])
Out[4]: '1252277511746183168'

In [5]: api._ensure_user_id(Out[3][:-1]) # doesn't exist
Out[5]: '125227751174618316'

In [6]: api._ensure_user_id("Twitter")
Out[6]: '783214'

In [7]: api._ensure_user_id("783214") # both screen name and ID
Out[7]: '783214'

In [8]: api._ensure_user_id("42069") # screen name, not ID
Out[8]: '17334495'
```