### PR TITLE
Support using list of integer ids for user lookup

### DIFF
--- a/twarc/client.py
+++ b/twarc/client.py
@@ -359,7 +359,7 @@ class Twarc(object):
             return resp.json()
 
         for id in ids:
-            lookup_ids.append(id.strip())
+            lookup_ids.append(str(id).strip())
             if len(lookup_ids) == 100:
                 for u in do_lookup():
                     yield u


### PR DESCRIPTION
this fails when passing in a list of ints because of the call to .strip() without first turning it into a string. This way both screen names, IDs as strings `"42"` and integers `42` can be passed in.

example:

```python
from twarc.client import Twarc

user_ids = [657693, 183709371, 7588892, 38895958]
user_ids_str = ["657693", "183709371", "7588892", "38895958"]


t = Twarc(consumer_key="...", consumer_secret="...")

user_objects = list(t.user_lookup(ids=user_ids))

same_user_objects = list(t.user_lookup(ids=user_ids_str))

```