### PR TITLE
Fix progress bar failing when all tweets are deleted

### DIFF
--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -202,9 +202,10 @@ class FileSizeProgressBar(tqdm):
         self, result, field="id", error_resource_type=None, error_parameter="ids"
     ):
         try:
-            for item in result["data"]:
-                # Use the length of the id / name and a newline to match original file
-                self.update(len(item[field]) + len("\n"))
+            if "data" in result:
+                for item in result["data"]:
+                    # Use the length of the id / name and a newline to match original file
+                    self.update(len(item[field]) + len("\n"))
             if error_resource_type and "errors" in result:
                 for error in result["errors"]:
                     # Account for deleted data


### PR DESCRIPTION
When hydrating a dataset with all deleted tweets for example, the `FileSizeProgressBar` breaks. Can also happen in other situations when there's no data in response, only errors.