### PR TITLE
Move last-30-days by default fix from the CLI to the client

### DIFF
--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -212,7 +212,8 @@ class Twarc2:
             until_id (int):
                 Return all tweets up to this tweet_id.
             start_time (datetime):
-                Return all tweets after this time (UTC datetime).
+                Return all tweets after this time (UTC datetime). If none of start_time, since_id, or until_id
+                are specified, this defaults to 2006-3-21 to search the entire history of Twitter.
             end_time (datetime):
                 Return all tweets before this time (UTC datetime).
             max_results (int):
@@ -222,6 +223,12 @@ class Twarc2:
             generator[dict]: a generator, dict for each paginated response.
         """
         url = "https://api.twitter.com/2/tweets/search/all"
+
+        # start time defaults to the beginning of Twitter to override the
+        # default of the last month. Only do this if start_time is not already
+        # specified and since_id and until_id aren't being used
+        if start_time is None and since_id is None and until_id is None:
+            start_time = datetime.datetime(2006, 3, 21, tzinfo=datetime.timezone.utc)
 
         return self._search(
             url,

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -234,12 +234,6 @@ def _search(
         # default number of tweets per response 500 when not set otherwise
         if max_results == 0:
             max_results = 100  # temp fix for #504
-
-        # start time defaults to the beginning of Twitter to override the
-        # default of the last month. Only do this if start_time is not already
-        # specified and since_id and until_id aren't being used
-        if start_time is None and since_id is None and until_id is None:
-            start_time = datetime.datetime(2006, 3, 21, tzinfo=datetime.timezone.utc)
     else:
         if max_results == 0:
             max_results = 100


### PR DESCRIPTION
This fixes bugs in timelines and conversations, which use the
search_all endpoint without the fix for the new API behaviour, therefore 
limiting them to the last 30 days only even when using the academic
archive endpoints.

This fix just moves the default start_time set in the CLI app to
the client app, so it will apply by default to all uses of the
search_all method.