### PR TITLE
Added places command

### DIFF
--- a/docs/twarc2_en_us.md
+++ b/docs/twarc2_en_us.md
@@ -222,6 +222,34 @@ The input file, `ids.txt` is expected to be a file that contains a tweet identif
 
 Twitter API's [Terms of Service](https://dev.twitter.com/overview/terms/policy#6._Be_a_Good_Partner_to_Twitter) discourage people from making large amounts of raw Twitter data available on the Web.  The data can be used for research and archived for local use, but not shared with the world. Twitter does allow files of tweet identifiers to be shared, which can be useful when you would like to make a dataset of tweets available.  You can then use Twitter's API to *hydrate* the data, or to retrieve the full JSON for each identifier. This is particularly important for [verification](https://en.wikipedia.org/wiki/Reproducibility) of social media research.
 
+## Places
+
+The search and stream APIs allow you to search by places. But in order to use
+them you need to know the identifier for a specific place. twarc's
+`places` command will let you search by the place name, geo coordinates, or ip
+address. For example: 
+
+    twarc2 places Ferguson                 
+
+Which will output something like:
+
+```shell
+$ twarc2 places Ferguson                 
+Ferguson, MO, United States [id=0a62ce0f6aa37536]
+Ruisseau-Ferguson, Québec, Canada [id=25283a1f59449e8f]
+Ferguson, Victoria, Australia [id=2538e66b7e5c082c]
+Ferguson Road Initiative, Dallas, United States [id=368aad647311292a]
+Ferguson, Western Australia, Australia [id=45f20c78d803ad84]
+Ferguson, PA, United States [id=00c92e14361c9674]
+Ferguson, KY, United States [id=0190ea5612aaae32]
+```
+
+You can then use one of the ids in a search:
+
+    twarc2 search "place:0a62ce0f6aa37536" tweets.jsonl
+
+You can also search by geo-coordinates (lat,lon) and IP address. If you would prefer to see the full JSON response with the bounding boxes use the `--json` option.
+
 # Command Line Usage
 
 Below is what you see when you run `twarc2 --help`.

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -30,13 +30,13 @@ T = twarc.Twarc2(
 )
 
 
-def atest_version():
+def test_version():
     import setup
 
     assert setup.version == twarc.version
 
 
-def atest_auth_types_interaction():
+def test_auth_types_interaction():
     """
     Test the various options for configuration work as expected.
     """
@@ -77,7 +77,7 @@ def atest_auth_types_interaction():
         tw.sample()
 
 
-def atest_sample():
+def test_sample():
     # event to tell the filter stream to close
     event = threading.Event()
 
@@ -95,7 +95,7 @@ def atest_sample():
     assert count == 11
 
 
-def atest_search_recent():
+def test_search_recent():
 
     found_tweets = 0
     pages = 0
@@ -111,7 +111,7 @@ def atest_search_recent():
     assert 200 <= found_tweets <= 300
 
 
-def atest_counts_recent():
+def test_counts_recent():
 
     found_counts = 0
 
@@ -123,7 +123,7 @@ def atest_counts_recent():
     assert 7 <= found_counts <= 8
 
 
-def atest_search_times():
+def test_search_times():
     found = False
     now = datetime.datetime.now(tz=pytz.timezone("Australia/Melbourne"))
     # twitter api doesn't resolve microseconds so strip them for comparison
@@ -144,7 +144,7 @@ def atest_search_times():
     assert found
 
 
-def atest_user_ids_lookup():
+def test_user_ids_lookup():
     users_found = 0
     users_not_found = 0
 
@@ -164,7 +164,7 @@ def atest_user_ids_lookup():
     assert users_found + users_not_found == 999
 
 
-def atest_usernames_lookup():
+def test_usernames_lookup():
     users_found = 0
     usernames = ["jack", "barackobama", "rihanna"]
     for response in T.user_lookup(usernames, usernames=True):
@@ -173,7 +173,7 @@ def atest_usernames_lookup():
     assert users_found == 3
 
 
-def atest_tweet_lookup():
+def test_tweet_lookup():
 
     tweets_found = 0
     tweets_not_found = 0
@@ -202,7 +202,7 @@ def atest_tweet_lookup():
     os.environ.get("GITHUB_ACTIONS") != None,
     reason="stream() seems to throw a 400 error under GitHub Actions?!",
 )
-def atest_stream():
+def test_stream():
     # remove any active stream rules
     rules = T.get_stream_rules()
     if "data" in rules and len(rules["data"]) > 0:
@@ -255,7 +255,7 @@ def atest_stream():
     assert "data" not in rules
 
 
-def atest_timeline():
+def test_timeline():
     """
     Test the user timeline endpoints.
 
@@ -276,7 +276,7 @@ def atest_timeline():
     assert found >= 200
 
 
-def atest_timeline_username():
+def test_timeline_username():
     """
     Test the user timeline endpoints with username.
 
@@ -297,12 +297,12 @@ def atest_timeline_username():
     assert found >= 200
 
 
-def atest_missing_timeline():
+def test_missing_timeline():
     results = T.timeline(1033441111677788160)
     assert len(list(results)) == 0
 
 
-def atest_follows():
+def test_follows():
     """
     Test followers and and following.
 
@@ -324,7 +324,7 @@ def atest_follows():
     assert found >= 1000
 
 
-def atest_follows_username():
+def test_follows_username():
     """
     Test followers and and following by username.
 
@@ -346,7 +346,7 @@ def atest_follows_username():
     assert found >= 1000
 
 
-def atest_flattened():
+def test_flattened():
     """
     This test uses the search API to test response flattening. It will look
     at each tweet to find evidence that all the expansions have worked. Once it
@@ -432,7 +432,7 @@ def atest_flattened():
     assert found_referenced_tweets, "found referenced tweets"
 
 
-def atest_ensure_flattened():
+def test_ensure_flattened():
     resp = next(T.search_recent("twitter", max_results=20))
 
     # flatten a response
@@ -485,7 +485,7 @@ def atest_ensure_flattened():
         twarc.expansions.ensure_flattened([[{"data": {"fake": "list_of_lists"}}]])
 
 
-def atest_ensure_user_id():
+def test_ensure_user_id():
     """
     Test _ensure_user_id's ability to discriminate correctly between IDs and
     screen names.
@@ -505,7 +505,7 @@ def atest_ensure_user_id():
     assert T._ensure_user_id(1033441111677788160) == "1033441111677788160"
 
 
-def atest_twarc_metadata():
+def test_twarc_metadata():
 
     # With metadata (default)
     event = threading.Event()
@@ -532,7 +532,7 @@ def atest_twarc_metadata():
     T.metadata = True
 
 
-def atest_docs_requirements():
+def test_docs_requirements():
     """
     Make sure that the mkdocs requirements has everything that is in the
     twarc requirements so the readthedocs build doesn't fail.

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -30,13 +30,13 @@ T = twarc.Twarc2(
 )
 
 
-def test_version():
+def atest_version():
     import setup
 
     assert setup.version == twarc.version
 
 
-def test_auth_types_interaction():
+def atest_auth_types_interaction():
     """
     Test the various options for configuration work as expected.
     """
@@ -77,7 +77,7 @@ def test_auth_types_interaction():
         tw.sample()
 
 
-def test_sample():
+def atest_sample():
     # event to tell the filter stream to close
     event = threading.Event()
 
@@ -95,7 +95,7 @@ def test_sample():
     assert count == 11
 
 
-def test_search_recent():
+def atest_search_recent():
 
     found_tweets = 0
     pages = 0
@@ -111,7 +111,7 @@ def test_search_recent():
     assert 200 <= found_tweets <= 300
 
 
-def test_counts_recent():
+def atest_counts_recent():
 
     found_counts = 0
 
@@ -123,7 +123,7 @@ def test_counts_recent():
     assert 7 <= found_counts <= 8
 
 
-def test_search_times():
+def atest_search_times():
     found = False
     now = datetime.datetime.now(tz=pytz.timezone("Australia/Melbourne"))
     # twitter api doesn't resolve microseconds so strip them for comparison
@@ -144,7 +144,7 @@ def test_search_times():
     assert found
 
 
-def test_user_ids_lookup():
+def atest_user_ids_lookup():
     users_found = 0
     users_not_found = 0
 
@@ -164,7 +164,7 @@ def test_user_ids_lookup():
     assert users_found + users_not_found == 999
 
 
-def test_usernames_lookup():
+def atest_usernames_lookup():
     users_found = 0
     usernames = ["jack", "barackobama", "rihanna"]
     for response in T.user_lookup(usernames, usernames=True):
@@ -173,7 +173,7 @@ def test_usernames_lookup():
     assert users_found == 3
 
 
-def test_tweet_lookup():
+def atest_tweet_lookup():
 
     tweets_found = 0
     tweets_not_found = 0
@@ -202,7 +202,7 @@ def test_tweet_lookup():
     os.environ.get("GITHUB_ACTIONS") != None,
     reason="stream() seems to throw a 400 error under GitHub Actions?!",
 )
-def test_stream():
+def atest_stream():
     # remove any active stream rules
     rules = T.get_stream_rules()
     if "data" in rules and len(rules["data"]) > 0:
@@ -255,7 +255,7 @@ def test_stream():
     assert "data" not in rules
 
 
-def test_timeline():
+def atest_timeline():
     """
     Test the user timeline endpoints.
 
@@ -276,7 +276,7 @@ def test_timeline():
     assert found >= 200
 
 
-def test_timeline_username():
+def atest_timeline_username():
     """
     Test the user timeline endpoints with username.
 
@@ -297,12 +297,12 @@ def test_timeline_username():
     assert found >= 200
 
 
-def test_missing_timeline():
+def atest_missing_timeline():
     results = T.timeline(1033441111677788160)
     assert len(list(results)) == 0
 
 
-def test_follows():
+def atest_follows():
     """
     Test followers and and following.
 
@@ -324,7 +324,7 @@ def test_follows():
     assert found >= 1000
 
 
-def test_follows_username():
+def atest_follows_username():
     """
     Test followers and and following by username.
 
@@ -346,7 +346,7 @@ def test_follows_username():
     assert found >= 1000
 
 
-def test_flattened():
+def atest_flattened():
     """
     This test uses the search API to test response flattening. It will look
     at each tweet to find evidence that all the expansions have worked. Once it
@@ -432,7 +432,7 @@ def test_flattened():
     assert found_referenced_tweets, "found referenced tweets"
 
 
-def test_ensure_flattened():
+def atest_ensure_flattened():
     resp = next(T.search_recent("twitter", max_results=20))
 
     # flatten a response
@@ -485,7 +485,7 @@ def test_ensure_flattened():
         twarc.expansions.ensure_flattened([[{"data": {"fake": "list_of_lists"}}]])
 
 
-def test_ensure_user_id():
+def atest_ensure_user_id():
     """
     Test _ensure_user_id's ability to discriminate correctly between IDs and
     screen names.
@@ -505,7 +505,7 @@ def test_ensure_user_id():
     assert T._ensure_user_id(1033441111677788160) == "1033441111677788160"
 
 
-def test_twarc_metadata():
+def atest_twarc_metadata():
 
     # With metadata (default)
     event = threading.Event()
@@ -532,7 +532,7 @@ def test_twarc_metadata():
     T.metadata = True
 
 
-def test_docs_requirements():
+def atest_docs_requirements():
     """
     Make sure that the mkdocs requirements has everything that is in the
     twarc requirements so the readthedocs build doesn't fail.
@@ -541,6 +541,10 @@ def test_docs_requirements():
     mkdocs_reqs = set(open("requirements-mkdocs.txt").read().split())
 
     assert twarc_reqs.issubset(mkdocs_reqs)
+
+
+def test_geo():
+    print(T.geo(query="Silver Spring"))
 
 
 def pick_id(id, objects):

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -958,6 +958,61 @@ class Twarc2:
         else:
             raise ValueError(f"Unknown response from twitter: {result}")
 
+    def geo(
+        self,
+        lat=None,
+        lon=None,
+        query=None,
+        ip=None,
+        granularity="neighborhood",
+        max_results=None,
+    ):
+        """
+        Gets geographic places that can be useful in queries. This is a v1.1
+        endpoint but is useful in querying the v2 API.
+
+        Calls [1.1/geo/search.json](https://api.twitter.com/1.1/geo/search.json)
+
+        Args:
+            lat (float): latitude to search around
+            lon (float): longitude to search around
+            query (str): text to match in the place name
+            ip (str): use the ip address to locate places
+            granularity (str) : neighborhood, city, admin, country
+            max_results (int): maximum results to return
+        """
+
+        params = {}
+        if lat and lon:
+            params["lat"] = lat
+            params["long"] = lon
+        elif query:
+            params["query"] = query
+        elif ip:
+            params["ip"] = ip
+        else:
+            raise ValueError("geo() needs either lat/lon, query or ip)")
+
+        if granularity not in ["neighborhood", "city", "admin", "country"]:
+            raise ValueError(
+                "{granularity} is not valid value for granularity, please use neighborhood, city, admin or country"
+            )
+        params["granularity"] = granularity
+
+        if max_results and type(max_results) != int:
+            raise ValueError("max_results must be an int")
+        params["max_results"] = max_results
+
+        url = "https://api.twitter.com/1.1/geo/search.json"
+
+        result = self.get(url, params=params)
+        if result.status_code == 200:
+            result = result.json()
+        else:
+            raise ValueError(f"Error from API, response: {result.status_code}")
+
+        return result
+
     def _id_exists(self, user):
         """
         Returns True if the user id exists

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -1490,15 +1490,15 @@ def flatten(infile, outfile, hide_progress):
 @click.option(
     "--type",
     "search_type",
-    type=click.Choice(["geo", "name", "ip"]),
+    type=click.Choice(["name", "geo", "ip"]),
     default="name",
-    help="How to search for places",
+    help="How to search for places (defaults to name)",
 )
 @click.option(
     "--granularity",
     type=click.Choice(["neighborhood", "city", "admin", "country"]),
     default="neighborhood",
-    help="What type of places to search for",
+    help="What type of places to search for (defaults to neighborhood)",
 )
 @click.option("--max-results", type=int, help="Maximum results to return")
 @click.option("--json", is_flag=True, help="Output raw JSON response")

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -1486,6 +1486,63 @@ def flatten(infile, outfile, hide_progress):
             progress.update(len(line))
 
 
+@twarc2.command("places")
+@click.option(
+    "--type",
+    "search_type",
+    type=click.Choice(["geo", "name", "ip"]),
+    default="name",
+    help="How to search for places",
+)
+@click.option(
+    "--granularity",
+    type=click.Choice(["neighborhood", "city", "admin", "country"]),
+    default="neighborhood",
+    help="What type of places to search for",
+)
+@click.option("--max-results", type=int, help="Maximum results to return")
+@click.option("--json", is_flag=True, help="Output raw JSON response")
+@click.argument("value")
+@click.argument("outfile", type=click.File("w"), default="-")
+@click.pass_obj
+@cli_api_error
+def places(T, value, outfile, search_type, granularity, max_results, json):
+    """
+    Search for places by place name, geo coordinates or ip address.
+    """
+    params = {"granularity": granularity}
+
+    if search_type == "name":
+        params["query"] = value
+    elif search_type == "ip":
+        params["ip"] = value
+    elif search_type == "geo":
+        try:
+            lat, lon = list(map(float, value.split(",")))
+            params = {"lat": lat, "lon": lon}
+        except:
+            click.echo("--geo must be lat,lon", err=True)
+
+    if max_results:
+        params["max_results"] = max_results
+
+    result = T.geo(**params)
+
+    if "errors" in result:
+        click.echo(_error_str(result["errors"]), err=True)
+    elif json:
+        _write(result, outfile)
+    else:
+        for place in result["result"]["places"]:
+            if granularity == "country":
+                line = "{0} [id={1}]".format(place["country"], place["id"])
+            else:
+                line = "{0}, {1} [id={2}]".format(
+                    place["full_name"], place["country"], place["id"]
+                )
+            click.echo(line)
+
+
 @twarc2.command("stream")
 @click.option("--limit", default=0, help="Maximum number of tweets to return")
 @click.argument("outfile", type=click.File("a+"), default="-")


### PR DESCRIPTION
Even though it's still on the 1.1 endpoint, now that you can search by place id I thought it was useful to be able to look these up from the command line.

```
Usage: twarc2 places [OPTIONS] VALUE [OUTFILE]

  Search for places by place name, geo coordinates or ip address.

Options:
  --type [geo|name|ip]            How to search for places
  --granularity [neighborhood|city|admin|country]
                                  What type of places to search for
  --max-results INTEGER           Maximum results to return
  --json                          Output raw JSON response
  --help                          Show this message and exit.
```