### PR TITLE
Add example configuration and script to build a windows installer

### DIFF
--- a/installer.cfg
+++ b/installer.cfg
@@ -1,0 +1,26 @@
+[Application]
+name=twarc
+version=2.8.0
+entry_point=twarc.command2:twarc2
+
+[Python]
+version=3.9.7
+bitness=64
+format=bundled
+
+[Include]
+# Requires downloading and/or creating necessary windows wheels locally
+# See windows_installer.sh
+local_wheels = wheels/*.whl
+
+packages=twarc
+
+# Other files and folders that should be installed
+files = LICENSE
+    README.md
+
+[Command twarc2]
+entry_point=twarc.command2:twarc2
+
+[Command twarc]
+entry_point=twarc.command:main

--- a/windows_installer.sh
+++ b/windows_installer.sh
@@ -1,0 +1,27 @@
+# This constructs a windows installer for this version of twarc, using pynsist
+# It assumes that nsis is present on the system, and that a Python interpreter
+# and Pip are present
+
+sudo apt install nsis
+
+pip install pynsist
+
+# First we're going to setup dependencies by downloading wheels
+# There's also a way to specify this in the nsis script, but this is more
+# explicit, and necessary for the one dependency that doesn't have a wheel
+# anyway.
+
+mkdir wheels
+
+# configobj doesn't have a wheel available, so we'll make a local one.
+pip wheel configobj --no-deps -w wheels
+
+# get wheels for everything else, ignoring the one wheel already present
+pip download -r requirements.txt -d wheels --platform win_amd64 --platform any --only-binary=:all: -f wheels/
+
+pynsist installer.cfg
+
+
+
+
+


### PR DESCRIPTION
This is a draft of what a windows installer looks like with pynsist.

I think in principle this could be automated to run on releases, with the built installer attached as an artifact to the release itself.

Things I haven't worked out yet:

- code signing, to avoid warnings about untrusted developers
- pynsist requires you specify an entrypoint, which creates a task bar entry, which is definitely odd for a command line program. Maybe that should open a browser and link to the twarc help about running as a command line application?