### PR TITLE
Add user-agent headers

### DIFF
--- a/test_twarc.py
+++ b/test_twarc.py
@@ -631,6 +631,7 @@ def test_hydrate():
 @patch("twarc.client.OAuth1Session", autospec=True)
 def test_connection_error_get(oauth1session_class):
     mock_oauth1session = MagicMock(spec=OAuth1Session)
+    mock_oauth1session.headers = {}
     oauth1session_class.return_value = mock_oauth1session
     mock_oauth1session.get.side_effect = requests.exceptions.ConnectionError
     t = twarc.Twarc(
@@ -650,6 +651,7 @@ def test_connection_error_get(oauth1session_class):
 @patch("twarc.client.OAuth1Session", autospec=True)
 def test_connection_error_post(oauth1session_class):
     mock_oauth1session = MagicMock(spec=OAuth1Session)
+    mock_oauth1session.headers = {}
     oauth1session_class.return_value = mock_oauth1session
     mock_oauth1session.post.side_effect = requests.exceptions.ConnectionError
     t = twarc.Twarc(

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -33,10 +33,11 @@ T = twarc.Twarc2(
 
 def test_version():
     import setup
+
     assert setup.version == version
 
     assert user_agent
-    assert f'twarc/{version}' in user_agent
+    assert f"twarc/{version}" in user_agent
 
 
 def test_auth_types_interaction():

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -1,5 +1,4 @@
 import os
-import json
 import pytz
 import twarc
 import dotenv
@@ -8,7 +7,9 @@ import logging
 import pathlib
 import datetime
 import threading
+
 from unittest import TestCase
+from twarc.version import version, user_agent
 
 dotenv.load_dotenv()
 consumer_key = os.environ.get("CONSUMER_KEY")
@@ -32,8 +33,10 @@ T = twarc.Twarc2(
 
 def test_version():
     import setup
+    assert setup.version == version
 
-    assert setup.version == twarc.version
+    assert user_agent
+    assert f'twarc/{version}' in user_agent
 
 
 def test_auth_types_interaction():

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -14,6 +14,8 @@ from requests.exceptions import ConnectionError
 from requests.packages.urllib3.exceptions import ProtocolError
 
 from .decorators import *
+from twarc.version import version, user_agent
+
 from requests_oauthlib import OAuth1, OAuth1Session, OAuth2Session
 from oauthlib.oauth2 import BackendApplicationClient
 
@@ -937,6 +939,9 @@ class Twarc(object):
                 client_secret=self.consumer_secret,
             )
             self.client = oauth
+
+        if self.client:
+            self.client.headers.update({"User-Agent": user_agent("v1.1")})
 
     def get_keys(self):
         """

--- a/twarc/client.py
+++ b/twarc/client.py
@@ -941,7 +941,7 @@ class Twarc(object):
             self.client = oauth
 
         if self.client:
-            self.client.headers.update({"User-Agent": user_agent("v1.1")})
+            self.client.headers.update({"User-Agent": user_agent})
 
     def get_keys(self):
         """

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -24,7 +24,7 @@ from twarc.expansions import (
     ensure_flattened,
 )
 from twarc.decorators2 import *
-from twarc.version import version
+from twarc.version import version, user_agent
 
 
 log = logging.getLogger("twarc")
@@ -1270,6 +1270,9 @@ class Twarc2:
                 resource_owner_key=self.access_token,
                 resource_owner_secret=self.access_token_secret,
             )
+
+        if self.client:
+            self.client.headers.update({"User-Agent": user_agent(f"v2")})
 
     @requires_app_auth
     def compliance_job_list(self, job_type, status):

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -1272,7 +1272,7 @@ class Twarc2:
             )
 
         if self.client:
-            self.client.headers.update({"User-Agent": user_agent(f"v2")})
+            self.client.headers.update({"User-Agent": user_agent})
 
     @requires_app_auth
     def compliance_job_list(self, job_type, status):

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -777,7 +777,7 @@ class Twarc2:
                     log.error(f"too many consecutive errors ({tries}). stopping")
                     return
                 else:
-                    secs = errors ** 2
+                    secs = errors**2
                     log.info("sleeping %s seconds before reconnecting", secs)
                     time.sleep(secs)
 

--- a/twarc/decorators2.py
+++ b/twarc/decorators2.py
@@ -91,7 +91,7 @@ def rate_limit(f, tries=30):
                 if errors > tries:
                     log.warning(f"too many errors ({tries}) from Twitter, giving up")
                     resp.raise_for_status()
-                seconds = errors ** 2
+                seconds = errors**2
                 log.warning(
                     "caught %s from Twitter API, sleeping %s", resp.status_code, seconds
                 )
@@ -142,7 +142,7 @@ def catch_request_exceptions(f, tries=30):
                 if errors > tries:
                     log.error(f"giving up, too many request exceptions: {tries}")
                     raise e
-                seconds = errors ** 2
+                seconds = errors**2
                 log.info("sleeping %s", seconds)
                 time.sleep(seconds)
                 self.connect()

--- a/twarc/version.py
+++ b/twarc/version.py
@@ -1,1 +1,7 @@
+import platform
+
 version = "2.9.1"
+
+
+def user_agent(api_version="v2"):
+    return f"twarc/{version} ({platform.system()} {platform.machine()}) API/{api_version} {platform.python_implementation()}/{platform.python_version()}"

--- a/twarc/version.py
+++ b/twarc/version.py
@@ -2,6 +2,4 @@ import platform
 
 version = "2.9.1"
 
-
-def user_agent(api_version="v2"):
-    return f"twarc/{version} ({platform.system()} {platform.machine()}) API/{api_version} {platform.python_implementation()}/{platform.python_version()}"
+user_agent = f"twarc/{version} ({platform.system()} {platform.machine()}) {platform.python_implementation()}/{platform.python_version()}"


### PR DESCRIPTION
fix #591 

The user agent is now:

```
twarc/2.9.1 (Linux x86_64) CPython/3.7.5
```

And for v2:

```
twarc/2.9.1 (Linux x86_64) CPython/3.7.5
```

where it's `twarc/2.9.1` is the version from `version.py`, `(OS Architecture)` is there to make sure OS gets parsed, but i didn't want to include a longer more detailed OS version, it should be enough to know if it's Linux, Mac, Windows, including the architecture makes sure it parses in a few user agent parsing things i've tried. `CPython/3.7.5` is the Python interpreter and version which should also be useful.

I think this is ok? not too identifying but not too sparse either. I'm open to suggestions on format / adding / removing things.