### PR TITLE
Avoid exceptions raised by CLI logging for stream/sample commands

### DIFF
--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -1053,7 +1053,8 @@ def sample(T, outfile, limit, **kwargs):
         if limit != 0 and count >= limit:
             event.set()
         _write(result, outfile)
-        if result:
+
+        if result and "data" in result:
             log.info("archived %s", result["data"]["id"])
 
 
@@ -1910,7 +1911,8 @@ def stream(T, outfile, limit, **kwargs):
             log.info(f"reached limit {limit}")
             event.set()
         _write(result, outfile)
-        if "data" in result:
+
+        if result and "data" in result:
             log.info("archived %s", result["data"]["id"])
 
 


### PR DESCRIPTION
For OperationalDisconnect errors, a response is streamed from the
API which causes the logging to fail because it assumes every
entry contains a "data" key.

This just makes sure that the data key is present before trying
to log an archived tweet ID.