### PR TITLE
Add the singular user command, analogous to the single tweet command

### DIFF
--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -1177,23 +1177,22 @@ def users(T, infile, outfile, usernames, hide_progress, **kwargs):
 @twarc2.command("user")
 @command_line_expansions_shortcuts
 @command_line_expansions_options
+@click.argument("name-or-id", type=click.Choice(["name", "id"]))
 @click.argument("user", type=str)
 @click.argument("outfile", type=click.File("w"), default="-")
-@click.option("--username", is_flag=True, default=False)
 @click.pass_obj
 @cli_api_error
-def user(T, user, outfile, username, **kwargs):
+def user(T, name_or_id, user, outfile, **kwargs):
     """
-    Get data for a single user id or username.
+    Get the profile data for a single user by either username or ID.
 
-    By default, user expects a single numeric Twitter user_id, so the
-    following will return the user profile for Twitter's founder:
+    To look up a user by ID:
 
-        twarc2 user 12
+        twarc2 user id 12
 
-    If you have a username, provide the --username flag:
+    To look up a user by username:
 
-        twarc2 user jack --username
+        twarc2 user name jack
 
     """
 
@@ -1202,6 +1201,8 @@ def user(T, user, outfile, username, **kwargs):
     kwargs.pop("media_fields", None)
     kwargs.pop("poll_fields", None)
     kwargs.pop("place_fields", None)
+
+    username = name_or_id == "name"
 
     user_data = list(T.user_lookup([user], username, **kwargs))
     _write(user_data, outfile)

--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -1174,6 +1174,39 @@ def users(T, infile, outfile, usernames, hide_progress, **kwargs):
                 progress.update_with_result(result, error_resource_type="user")
 
 
+@twarc2.command("user")
+@command_line_expansions_shortcuts
+@command_line_expansions_options
+@click.argument("user", type=str)
+@click.argument("outfile", type=click.File("w"), default="-")
+@click.option("--username", is_flag=True, default=False)
+@click.pass_obj
+@cli_api_error
+def user(T, user, outfile, username, **kwargs):
+    """
+    Get data for a single user id or username.
+
+    By default, user expects a single numeric Twitter user_id, so the
+    following will return the user profile for Twitter's founder:
+
+        twarc2 user 12
+
+    If you have a username, provide the --username flag:
+
+        twarc2 user jack --username
+
+    """
+
+    kwargs = _process_expansions_shortcuts(kwargs)
+    # Also remove media poll and place from kwargs, these are not valid for this endpoint:
+    kwargs.pop("media_fields", None)
+    kwargs.pop("poll_fields", None)
+    kwargs.pop("place_fields", None)
+
+    user_data = list(T.user_lookup([user], username, **kwargs))
+    _write(user_data, outfile)
+
+
 @twarc2.command("mentions")
 @command_line_search_options
 @command_line_expansions_shortcuts


### PR DESCRIPTION
This adds the user command, which takes a single user id. This is a direct analogue of the single tweet command, so we know have tweet/tweets and user/users.

Closes #598 