### PR TITLE
Workaround a limitation in the Twitter API returning empty page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         ACCESS_TOKEN: ${{ secrets.access_token }}
         ACCESS_TOKEN_SECRET: ${{ secrets.access_token_secret }}
         BEARER_TOKEN: ${{ secrets.bearer_token }}
+        SKIP_ACADEMIC_PRODUCT_TRACK: true
       run: python setup.py test
 
     - name: Ensure packages can be built

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -127,6 +127,10 @@ def test_counts_recent():
     assert 7 <= found_counts <= 8
 
 
+@pytest.mark.skipif(
+    os.environ.get("SKIP_ACADEMIC_PRODUCT_TRACK") != None,
+    reason="No Academic Research Product Track access",
+)
 def test_counts_empty_page():
 
     found_counts = 0

--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -127,6 +127,22 @@ def test_counts_recent():
     assert 7 <= found_counts <= 8
 
 
+def test_counts_empty_page():
+
+    found_counts = 0
+
+    for response_page in T.counts_all(
+        "beans",
+        start_time=datetime.datetime(2006, 3, 21),
+        end_time=datetime.datetime(2006, 6, 1),
+        granularity="day",
+    ):
+        counts = response_page["data"]
+        found_counts += len(counts)
+
+    assert found_counts == 72
+
+
 def test_search_times():
     found = False
     now = datetime.datetime.now(tz=pytz.timezone("Australia/Melbourne"))


### PR DESCRIPTION
In some cases, the Twitter API will return an empty page of results
from the counts API, without a next_token for pagination and only
a meta value indicating zero tweets in that count. This happens even 
when more results should definitely happen.

This adds a workaround for this, by detecting when the query has
terminated early based on the start-time provided, and restarting
the counts call with the last seen start-time as the new end-time.
This logic won't apply when no start-time is provided (only happens
when using the Twarc client, the CLI will always provide that value).

Hopefully we will get confirmation from Twitter that this is a bug
and will be able to remove this workaround.

Closes #602