### PR TITLE
Fix empty query file raising an error for the searches

### DIFF
--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -1675,6 +1675,8 @@ def searches(
     with FileLineProgressBar(infile, outfile, disable=hide_progress) as progress:
 
         merged_query = ""
+        extended_query = None
+        query = None
 
         for query in infile:
             query = query.strip()

--- a/twarc/version.py
+++ b/twarc/version.py
@@ -1,5 +1,5 @@
 import platform
 
-version = "2.10.0"
+version = "2.10.1"
 
 user_agent = f"twarc/{version} ({platform.system()} {platform.machine()}) {platform.python_implementation()}/{platform.python_version()}"


### PR DESCRIPTION
An empty file of queries would otherwise raise an exception when run with --combine-queries. Now it successfully does nothing.