### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10.

### DIFF
--- a/utils/media2warc.py
+++ b/utils/media2warc.py
@@ -251,11 +251,11 @@ def main():
 
     for i in range(threads):
         t = GetResource(q)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
     wt = WriteWarc(out_queue, os.path.join(args.archive_dir, "warc.warc"))
-    wt.setDaemon(True)
+    wt.daemon = True
     wt.start()
 
     q.join()


### PR DESCRIPTION
The camelcase methods were deprecated in Python 3.10 in python/cpython#25174
