### PR TITLE
Ensure error is raised from _ensure_user when the user doesn't exist

### DIFF
--- a/test_twarc2.py
+++ b/test_twarc2.py
@@ -625,6 +625,12 @@ def test_list_tweets():
     assert len(tweets) >= 90
 
 
+def test_user_lookup_non_existent():
+    with pytest.raises(ValueError):
+        # This user does not exist, and a value error should be raised
+        T._ensure_user("noasdfasdf")
+
+
 def test_twarc_metadata():
 
     # With metadata (default)

--- a/twarc/client2.py
+++ b/twarc/client2.py
@@ -22,7 +22,6 @@ from twarc.expansions import (
     POLL_FIELDS,
     PLACE_FIELDS,
     LIST_FIELDS,
-    ensure_flattened,
 )
 from twarc.decorators2 import *
 from twarc.version import version, user_agent
@@ -1883,11 +1882,12 @@ class Twarc2:
 
         lookup = []
         if len(user) > 15 or (is_numeric and self._id_exists(user)):
-            lookup = ensure_flattened(list(self.user_lookup([user])))
+            lookup = list(self.user_lookup([user]))[0]
         else:
-            lookup = ensure_flattened(list(self.user_lookup([user], usernames=True)))
-        if lookup:
-            return lookup[-1]
+            lookup = list(self.user_lookup([user], usernames=True))[0]
+
+        if "data" in lookup:
+            return lookup["data"][0]
         else:
             raise ValueError(f"No such user {user}")
 


### PR DESCRIPTION
Refactors _ensure_user to not rely on ensure_flattened, and handle
the response directly, as we know exactly what to expect here.