### PR TITLE
Fix bug where --max-results could not be set with --no-context-annota…

### DIFF
--- a/twarc/command2.py
+++ b/twarc/command2.py
@@ -423,7 +423,7 @@ def _validate_max_results(context, parameter, value):
             )
         if value < 10 or value > 500:
             raise click.BadParameter("--max-results must be between 10 and 500")
-        if value > 100 and has_context_annotations:
+        if value > 100 and (has_context_annotations and not no_context_annotations_set):
             raise click.BadParameter(
                 "--max-results cannot be greater than 100 when using context annotations. Set --no-context-annotations to remove them, or don't specify them in --tweet-fields."
             )


### PR DESCRIPTION
…tions

Previously this command:

`twarc2 search --archive --max-results 200 --no-context-annotations banana --limit 100`

Would fail with the error:

```
Error: Invalid value for '--max-results': --max-results cannot be greater
than 100 when using context annotations. Set --no-context-annotations to
remove them, or don't specify them in --tweet-fields.
```

This was occuring because _validate_max_results is called before
applying --no-context-annotations, this change just checks
no_context_annotations as well.