### PR TITLE
Add additional expansions and fields for the new tweet edit related API parameters

### DIFF
--- a/test_twarc.py
+++ b/test_twarc.py
@@ -625,7 +625,7 @@ def test_hydrate():
     for tweet in T.hydrate(iter(ids)):
         assert tweet["id_str"]
         count += 1
-    assert count > 90  # may need to adjust as these might get deleted
+    assert count > 80  # may need to adjust as these might get deleted
 
 
 @patch("twarc.client.OAuth1Session", autospec=True)

--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -22,7 +22,9 @@ EXPANSIONS = [
     "attachments.poll_ids",
     "attachments.media_keys",
     "geo.place_id",
+    "edit_history_tweet_ids",
 ]
+
 
 USER_FIELDS = [
     "created_at",
@@ -62,6 +64,7 @@ TWEET_FIELDS = [
     "reply_settings",
     "source",
     "withheld",
+    "edit_controls",
 ]
 
 MEDIA_FIELDS = [

--- a/twarc/version.py
+++ b/twarc/version.py
@@ -1,5 +1,5 @@
 import platform
 
-version = "2.11.3"
+version = "2.12.0"
 
 user_agent = f"twarc/{version} ({platform.system()} {platform.machine()}) {platform.python_implementation()}/{platform.python_version()}"


### PR DESCRIPTION
This PR adds the new field and expansion to capture the full history for edited versions of tweets. Note that the `edit_history_tweet_ids` field is a default field and we don't need to do anything additional to capture this. 