### PR TITLE
Add ability to configure max retries for v1.1 server errors

### DIFF
--- a/twarc/client.py
+++ b/twarc/client.py
@@ -51,6 +51,7 @@ class Twarc(object):
         access_token_secret=None,
         connection_errors=0,
         http_errors=0,
+        max_server_error_retries=30,
         config=None,
         profile="",
         protected=False,
@@ -76,6 +77,7 @@ class Twarc(object):
         self.access_token_secret = access_token_secret
         self.connection_errors = connection_errors
         self.http_errors = http_errors
+        self.max_server_error_retries = max_server_error_retries
         self.profile = profile
         self.client = None
         self.last_response = None
@@ -144,7 +146,11 @@ class Twarc(object):
             if max_id:
                 params["max_id"] = max_id
 
-            resp = self.get(url, params=params)
+            resp = self.get(
+                url,
+                params=params,
+                max_server_error_retries=self.max_server_error_retries,
+            )
 
             retrieved_pages += 1
             statuses = resp.json()["statuses"]
@@ -237,7 +243,11 @@ class Twarc(object):
         count = 0
         stop = False
         while not stop:
-            resp = self.get(url, params=params)
+            resp = self.get(
+                url,
+                params=params,
+                max_server_error_retries=self.max_server_error_retries,
+            )
             if resp.status_code == 200:
                 data = resp.json()
                 for tweet in data["results"]:
@@ -293,7 +303,12 @@ class Twarc(object):
                 params["max_id"] = max_id
 
             try:
-                resp = self.get(url, params=params, allow_404=True)
+                resp = self.get(
+                    url,
+                    params=params,
+                    allow_404=True,
+                    max_server_error_retries=self.max_server_error_retries,
+                )
                 retrieved_pages += 1
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
@@ -355,7 +370,12 @@ class Twarc(object):
             url = "https://api.twitter.com/1.1/users/lookup.json"
             params = {id_type: ids_str}
             try:
-                resp = self.get(url, params=params, allow_404=True)
+                resp = self.get(
+                    url,
+                    params=params,
+                    allow_404=True,
+                    max_server_error_retries=self.max_server_error_retries,
+                )
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
                     log.warning("no users matching %s", ids_str)
@@ -391,7 +411,12 @@ class Twarc(object):
 
         while params["cursor"] != 0:
             try:
-                resp = self.get(url, params=params, allow_404=True)
+                resp = self.get(
+                    url,
+                    params=params,
+                    allow_404=True,
+                    max_server_error_retries=self.max_server_error_retries,
+                )
                 retrieved_pages += 1
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
@@ -424,7 +449,12 @@ class Twarc(object):
 
         while params["cursor"] != 0:
             try:
-                resp = self.get(url, params=params, allow_404=True)
+                resp = self.get(
+                    url,
+                    params=params,
+                    allow_404=True,
+                    max_server_error_retries=self.max_server_error_retries,
+                )
                 retrieved_pages += 1
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
@@ -658,7 +688,12 @@ class Twarc(object):
                 tweet_id
             )
             try:
-                resp = self.get(url, params={"count": 100}, allow_404=True)
+                resp = self.get(
+                    url,
+                    params={"count": 100},
+                    allow_404=True,
+                    max_server_error_retries=self.max_server_error_retries,
+                )
                 for tweet in resp.json():
                     yield tweet
             except requests.exceptions.HTTPError as e:
@@ -671,7 +706,7 @@ class Twarc(object):
         """
         url = "https://api.twitter.com/1.1/trends/available.json"
         try:
-            resp = self.get(url)
+            resp = self.get(url, max_server_error_retries=self.max_server_error_retries)
         except requests.exceptions.HTTPError as e:
             raise e
         return resp.json()
@@ -687,7 +722,12 @@ class Twarc(object):
         if exclude:
             params["exclude"] = exclude
         try:
-            resp = self.get(url, params=params, allow_404=True)
+            resp = self.get(
+                url,
+                params=params,
+                allow_404=True,
+                max_server_error_retries=self.max_server_error_retries,
+            )
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 log.info("no region matching WOEID %s", woeid)
@@ -701,7 +741,11 @@ class Twarc(object):
         url = "https://api.twitter.com/1.1/trends/closest.json"
         params = {"lat": lat, "long": lon}
         try:
-            resp = self.get(url, params=params)
+            resp = self.get(
+                url,
+                params=params,
+                max_server_error_retries=self.max_server_error_retries,
+            )
         except requests.exceptions.HTTPError as e:
             raise e
         return resp.json()
@@ -789,7 +833,12 @@ class Twarc(object):
 
         while params["cursor"] != 0:
             try:
-                resp = self.get(url, params=params, allow_404=True)
+                resp = self.get(
+                    url,
+                    params=params,
+                    allow_404=True,
+                    max_server_error_retries=self.max_server_error_retries,
+                )
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
                     log.error("no matching list")
@@ -813,7 +862,9 @@ class Twarc(object):
         url = "https://publish.twitter.com/oembed"
 
         params["url"] = tweet_url
-        resp = self.get(url, params=params)
+        resp = self.get(
+            url, params=params, max_server_error_retries=self.max_server_error_retries
+        )
 
         return resp.json()
 
@@ -1010,7 +1061,7 @@ class Twarc(object):
                 # Need to explicitly reconnect to confirm the current creds
                 # are used in the session object.
                 self.connect()
-                self.get(url)
+                self.get(url, max_server_error_retries=self.max_server_error_retries)
                 return True
             except requests.HTTPError as e:
                 if e.response.status_code == 401:

--- a/twarc/decorators.py
+++ b/twarc/decorators.py
@@ -15,7 +15,7 @@ def rate_limit(f):
     issue the API call again.
     """
 
-    def new_f(*args, **kwargs):
+    def new_f(*args, max_server_error_retries=30, **kwargs):
         errors = 0
         while True:
             resp = f(*args, **kwargs)
@@ -56,7 +56,7 @@ def rate_limit(f):
                 resp.url.startswith("https://api.twitter.com/2/tweets/search/all")
             ):
                 errors += 1
-                if errors > 30:
+                if errors > max_server_error_retries:
                     log.warning("too many errors from Twitter, giving up")
                     resp.raise_for_status()
                 # Shorter wait time than other endpoints for this specific case. Also
@@ -76,7 +76,7 @@ def rate_limit(f):
                 time.sleep(seconds)
             elif resp.status_code >= 500:
                 errors += 1
-                if errors > 30:
+                if errors > max_server_error_retries:
                     log.warning("too many errors from Twitter, giving up")
                     resp.raise_for_status()
                 seconds = 60 * errors


### PR DESCRIPTION
Given the increasing instability of the v1.1 API, it's helpful to be able to tune the number of retries for server errors.

- Adds max_server_error_retries param to the v1.1 client retaining old value of 30 as default value
- Pass max_server_error_retries through the rate_limit decorator
- Pass max_server_error_retries through uses of Twarc.get() in client.py

Given I haven't consulted with anyone on this change, please let me know what you think and I'm very happy to alter it!

Some questions I have for you all:

- Do you think the client initialisation is an appropriate place to expose the parameter?
- Should the parameter be exposed in the CLI as well as in the library?
- I passed the parameter through all usages of Twarc.get() in client.py, but not in the usages in utils/deletes.py as those are a bit different as they initialise their own client. What are your thoughts on how they should handle the parameter?
- Should I pass the parameter through Twarc.post() as well so they are also configurable? Should they possibly be a separate parameter for posts rather than gets as they're for different purposes so people may want different values?

For further context, I'm suggesting this change because we're seeing an increasing number of 500 errors returned from the v1.1 timeline endpoint, which is not surprising given everything that's going on at Twitter. For my usage of the endpoint, I'd much rather skip over that request earlier and move on to my next request - we are finding some requests do reach the 30 retries! I'd imagine that other people may want to retry for longer to increase their chances of getting the data they want.