### PR TITLE
add `verified_type` user field

### DIFF
--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -40,6 +40,7 @@ USER_FIELDS = [
     "url",
     "username",
     "verified",
+    "verified_type",
     "withheld",
 ]
 


### PR DESCRIPTION
https://twitter.com/suhemparack/status/1611085481395224576

> 1. Tweet view count is available as impression_count under public_metrics
> 2. source field is removed from the API
> 3. verified_type is supported a user field to indicate account verification type (business, government, blue or none)

Keeping the `source` field however, as this needs to be backward compatible. `public_metrics` is there already, so it doesn't need changing, and impressions are visible from Dec 15th 2022 for the record.