### PR TITLE
Support archiving Tweets with more than 280 characters

### DIFF
--- a/twarc/expansions.py
+++ b/twarc/expansions.py
@@ -67,6 +67,7 @@ TWEET_FIELDS = [
     "withheld",
     "edit_controls",
     "edit_history_tweet_ids",
+    "note_tweet",
 ]
 
 MEDIA_FIELDS = [


### PR DESCRIPTION
Adds `note_tweet` to `tweet.fields`. This is necessary to support the new 10k long "note" Tweets available to Twitter Blue subscribers (the existing `text` field only includes a truncated Tweet). 

From the docs:

> Information about Tweets with more than 280 characters.
> 
> To return this field, add `tweet.fields=note_tweet` in the request's query parameter.

https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets
https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/get-users-id-liked_tweets
etc.